### PR TITLE
BUG: fix check_zero/check_null to pass function names.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,9 @@
 from setuptools import setup
 
 setup(
-    name='mini_pywin32',
+    name='pywin32-ctypes',
     version='0.0.1.dev1',
     author='Enthought Inc',
     author_email='info@enthought.com',
-    packages=['wine32ctypes', 'wine32ctypes.tests'],
+    packages=['win32ctypes', 'win32ctypes.tests'],
     license="BSD")

--- a/win32ctypes/_util.py
+++ b/win32ctypes/_util.py
@@ -26,17 +26,30 @@ def function_factory(
     return function
 
 
-def check_null(result, func, arguments, *args):
-    if result is None:
-        code = GetLastError()
-        description = FormatError(code).strip()
-        raise error(code, func, description)
-    return result
+def check_null_factory(func_name=None):
+    def check_null(result, func, arguments, *args):
+        if result is None:
+            code = GetLastError()
+            description = FormatError(code).strip()
+            if func_name is None:
+                raise error(code, func.__name__, description)
+            else:
+                raise error(code, func_name, description)
+        return result
+    return check_null
 
+check_null = check_null_factory()
 
-def check_zero(result, func, arguments, *args):
-    if result == 0:
-        code = GetLastError()
-        description = FormatError(code).strip()
-        raise error(code, func, description)
-    return result
+def check_zero_factory(func_name=None):
+    def check_zero(result, func, arguments, *args):
+        if result == 0:
+            code = GetLastError()
+            description = FormatError(code).strip()
+            if func_name is None:
+                raise error(code, func.__name__, description)
+            else:
+                raise error(code, func_name, description)
+        return result
+    return check_zero
+
+check_zero = check_zero_factory()

--- a/win32ctypes/_win32cred.py
+++ b/win32ctypes/_win32cred.py
@@ -18,7 +18,7 @@ from ctypes.wintypes import (
     BOOL, DWORD, FILETIME, c_void_p, c_wchar_p, LPCWSTR)
 
 from ._common import LPBYTE
-from ._util import function_factory, check_zero
+from ._util import function_factory, check_zero, check_zero_factory
 
 
 class CREDENTIAL(Structure):
@@ -46,16 +46,16 @@ _CredWrite = function_factory(
     advapi.CredWriteW,
     [PCREDENTIAL, DWORD],
     BOOL,
-    check_zero)
+    check_zero_factory("CredWrite"))
 
 _CredRead = function_factory(
     advapi.CredReadW,
     [LPCWSTR, DWORD, DWORD, POINTER(PCREDENTIAL)],
     BOOL,
-    check_zero)
+    check_zero_factory("CredRead"))
 
 _CredDelete = function_factory(
     advapi.CredDeleteW,
     [LPCWSTR, DWORD, DWORD],
     BOOL,
-    check_zero)
+    check_zero_factory("CredDelete"))

--- a/win32ctypes/tests/test_win32cred.py
+++ b/win32ctypes/tests/test_win32cred.py
@@ -105,6 +105,7 @@ class TestCred(unittest.TestCase):
         with self.assertRaises(error) as ctx:
             CredRead(target, CRED_TYPE_GENERIC)
         self.assertEqual(ctx.exception.winerror, ERROR_NOT_FOUND)
+        self.assertEqual(ctx.exception.funcname, "CredRead")
 
     def test_delete_doesnt_exists(self):
         target = "Floupi_doesnt_exists@MiniPyWin32"
@@ -112,3 +113,4 @@ class TestCred(unittest.TestCase):
         with self.assertRaises(error) as ctx:
             CredDelete(target, CRED_TYPE_GENERIC)
         self.assertEqual(ctx.exception.winerror, ERROR_NOT_FOUND)
+        self.assertEqual(ctx.exception.funcname, "CredDelete")


### PR DESCRIPTION
We were not completely compatible with pywin32 in case of windows errors, because pywin32 create a triplet (windows error, function name, description), and we were passing (windows error, function object, description).

This PR also fixed the setup.py that was broken, I can split that up if that bothers the reviewer.
