### PR TITLE
Fix issue 21

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,7 +1,7 @@
 [run]
 branch = True
 source = win32ctypes
-omit = win32ctypes/tests/*
+omit = */tests/*
 
 [report]
 # Regexes for lines to exclude from consideration

--- a/scripts/run_tests_wine.sh
+++ b/scripts/run_tests_wine.sh
@@ -15,10 +15,14 @@ else
     exit 1;
 fi
 
+mkdir -p testing
+cp .coveragerc testing/
+cd testing
 wine ${COVERAGE} erase
 if [ "${TRAVIS_PYTHON_VERSION}" = "2.6" ]; then
-    wine ${COVERAGE} run -m unittest2 discover -v
+    wine ${COVERAGE} run -m unittest2 discover win32ctypes -v
 else
-    wine ${COVERAGE} run -m unittest discover -v
+    wine ${COVERAGE} run -m unittest discover win32ctypes -v
 fi
+dir
 wine ${COVERAGE} report

--- a/setup.py
+++ b/setup.py
@@ -12,4 +12,7 @@ setup(
         "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3.2",
         "Programming Language :: Python :: 3.3",
-    ])
+    ],
+    use_2to3=True,
+    zip_safe=False,
+)

--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,11 @@
-from setuptools import setup
+from setuptools import setup, find_packages
 
 setup(
     name='pywin32-ctypes',
     version='0.0.2.dev1',
     author='Enthought Inc',
     author_email='info@enthought.com',
-    packages=['win32ctypes', 'win32ctypes.tests'],
+    packages=find_packages(),
     license="BSD",
     classifiers=[
         "Programming Language :: Python :: 2.6",

--- a/win32ctypes/core/ctypes/_common.py
+++ b/win32ctypes/core/ctypes/_common.py
@@ -30,3 +30,5 @@ else:
     _PyBytes_FromStringAndSize = function_factory(
         pythonapi.PyString_FromStringAndSize,
         return_type=py_object)
+
+IS_INTRESOURCE = lambda x: x >> 16 == 0

--- a/win32ctypes/core/ctypes/_kernel32.py
+++ b/win32ctypes/core/ctypes/_kernel32.py
@@ -12,7 +12,7 @@ from ctypes.wintypes import (
     BOOL, DWORD, HANDLE, HMODULE, LONG, LPCWSTR, WCHAR, WORD, HRSRC,
     HGLOBAL, LPVOID, UINT)
 
-from ._common import LONG_PTR, LPTSTR
+from ._common import LONG_PTR
 from ._util import check_null, check_zero, function_factory
 
 # While the lpszType is a LPTSTR we need to treat it as pointer
@@ -29,7 +29,8 @@ def ENUMRESTYPEPROC(callback):
         if typename >> 16 == 0:
             return callback(hModule, int(typename), param)
         else:
-            return True
+            name = ctypes.cast(typename, LPCWSTR)
+            return callback(hModule, name.value, param)
 
     return _ENUMRESTYPEPROC(wrapped)
 

--- a/win32ctypes/core/ctypes/_kernel32.py
+++ b/win32ctypes/core/ctypes/_kernel32.py
@@ -15,11 +15,10 @@ from ctypes.wintypes import (
 from ._common import LONG_PTR
 from ._util import check_null, check_zero, function_factory
 
-# While the lpszType is a LPTSTR we need to treat it as pointer
-_ENUMRESTYPEPROC = ctypes.WINFUNCTYPE(BOOL, HMODULE, LPVOID, LONG_PTR)
 ENUMRESNAMEPROC = ctypes.WINFUNCTYPE(BOOL, HMODULE, LONG, LONG, LONG_PTR)
 ENUMRESLANGPROC = ctypes.WINFUNCTYPE(
     BOOL, HMODULE, WCHAR, WCHAR, WORD, LONG_PTR)
+_ENUMRESTYPEPROC = ctypes.WINFUNCTYPE(BOOL, HMODULE, LPVOID, LONG_PTR)
 
 kernel32 = ctypes.windll.kernel32
 
@@ -53,18 +52,6 @@ _EnumResourceTypes = function_factory(
     BOOL,
     check_zero)
 
-_EnumResourceNames = function_factory(
-    kernel32.EnumResourceNamesW,
-    [HMODULE, DWORD, ENUMRESNAMEPROC, LONG_PTR],
-    BOOL,
-    check_zero)
-
-_EnumResourceLanguages = function_factory(
-    kernel32.EnumResourceLanguagesW,
-    [HMODULE, DWORD, DWORD, ENUMRESLANGPROC, LONG_PTR],
-    BOOL,
-    check_zero)
-
 _LoadResource = function_factory(
     kernel32.LoadResource,
     [HMODULE, HRSRC],
@@ -77,14 +64,46 @@ _LockResource = function_factory(
     LPVOID,
     check_null)
 
-_FindResourceEx = function_factory(
-    kernel32.FindResourceExW,
-    [HMODULE, DWORD, DWORD, WORD],
-    HRSRC,
-    check_null)
-
 _SizeofResource = function_factory(
     kernel32.SizeofResource,
     [HMODULE, HRSRC],
     DWORD,
     check_zero)
+
+_BaseEnumResourceNames = function_factory(
+    kernel32.EnumResourceNamesW,
+    [HMODULE, LPCWSTR, ENUMRESNAMEPROC, LONG_PTR],
+    BOOL,
+    check_zero)
+
+_BaseEnumResourceLanguages = function_factory(
+    kernel32.EnumResourceLanguagesW,
+    [HMODULE, LPCWSTR, LPCWSTR, ENUMRESLANGPROC, LONG_PTR],
+    BOOL,
+    check_zero)
+
+_BaseFindResourceEx = function_factory(
+    kernel32.FindResourceExW,
+    [HMODULE, LPCWSTR, LPCWSTR, WORD],
+    HRSRC,
+    check_null)
+
+
+def _EnumResourceNames(hModule, lpszType, lpEnumFunc, lParam):
+    resource_type = LPCWSTR(lpszType)
+    return _BaseEnumResourceNames(
+        hModule, resource_type, lpEnumFunc, lParam)
+
+
+def _EnumResourceLanguages(hModule, lpType, lpName, lpEnumFunc, lParam):
+    resource_type = LPCWSTR(lpType)
+    resource_name = LPCWSTR(lpName)
+    return _BaseEnumResourceLanguages(
+        hModule, resource_type, resource_name, lpEnumFunc, lParam)
+
+
+def _FindResourceEx(hModule, lpType, lpName, wLanguage):
+    resource_type = LPCWSTR(lpType)
+    resource_name = LPCWSTR(lpName)
+    return _BaseFindResourceEx(
+        hModule, resource_type, resource_name, wLanguage)

--- a/win32ctypes/core/ctypes/_kernel32.py
+++ b/win32ctypes/core/ctypes/_kernel32.py
@@ -12,7 +12,7 @@ from ctypes.wintypes import (
     BOOL, DWORD, HANDLE, HMODULE, LONG, LPCWSTR, WCHAR, WORD, HRSRC,
     HGLOBAL, LPVOID, UINT)
 
-from ._common import LONG_PTR
+from ._common import LONG_PTR, IS_INTRESOURCE
 from ._util import check_null, check_zero, function_factory
 
 _ENUMRESTYPEPROC = ctypes.WINFUNCTYPE(BOOL, HMODULE, LPVOID, LONG_PTR)
@@ -25,7 +25,7 @@ kernel32 = ctypes.windll.kernel32
 
 def ENUMRESTYPEPROC(callback):
     def wrapped(handle, type_, param):
-        if type_ >> 16 == 0:
+        if IS_INTRESOURCE(type_):
             type_ = int(type_)
         else:
             type_ = ctypes.cast(type_, LPCWSTR).value
@@ -36,11 +36,11 @@ def ENUMRESTYPEPROC(callback):
 
 def ENUMRESNAMEPROC(callback):
     def wrapped(handle, type_, name, param):
-        if type_ >> 16 == 0:
+        if IS_INTRESOURCE(name):
             type_ = int(type_)
         else:
             type_ = ctypes.cast(type_, LPCWSTR).value
-        if name >> 16 == 0:
+        if IS_INTRESOURCE(type_):
             name = int(name)
         else:
             name = ctypes.cast(name, LPCWSTR).value
@@ -51,11 +51,11 @@ def ENUMRESNAMEPROC(callback):
 
 def ENUMRESLANGPROC(callback):
     def wrapped(handle, type_, name, language, param):
-        if type_ >> 16 == 0:
+        if IS_INTRESOURCE(type_):
             type_ = int(type_)
         else:
             type_ = ctypes.cast(type_, LPCWSTR).value
-        if name >> 16 == 0:
+        if IS_INTRESOURCE(name):
             name = int(name)
         else:
             name = ctypes.cast(name, LPCWSTR).value

--- a/win32ctypes/core/ctypes/_kernel32.py
+++ b/win32ctypes/core/ctypes/_kernel32.py
@@ -36,11 +36,11 @@ def ENUMRESTYPEPROC(callback):
 
 def ENUMRESNAMEPROC(callback):
     def wrapped(handle, type_, name, param):
-        if IS_INTRESOURCE(name):
+        if IS_INTRESOURCE(type_):
             type_ = int(type_)
         else:
             type_ = ctypes.cast(type_, LPCWSTR).value
-        if IS_INTRESOURCE(type_):
+        if IS_INTRESOURCE(name):
             name = int(name)
         else:
             name = ctypes.cast(name, LPCWSTR).value

--- a/win32ctypes/pywin32/win32api.py
+++ b/win32ctypes/pywin32/win32api.py
@@ -24,8 +24,8 @@ def LoadLibraryEx(FileName, handle, flags):
 def EnumResourceTypes(hModule):
     resource_types = []
 
-    def callback(hModule, typeid, param):
-        resource_types.append(typeid)
+    def callback(hModule, type_, param):
+        resource_types.append(type_)
         return True
 
     with pywin32error():

--- a/win32ctypes/tests/test_win32api.py
+++ b/win32ctypes/tests/test_win32api.py
@@ -8,6 +8,7 @@
 
 import sys
 import unittest
+import contextlib
 
 import win32api
 from win32ctypes import pywin32
@@ -17,122 +18,93 @@ from win32ctypes.tests import compat
 
 class TestWin32API(compat.TestCase):
 
-    def setUp(self):
-        self.handle = None
+    module = pywin32.win32api
 
-    def tearDown(self):
-        if self.handle is not None:
-            self._free_library(win32api, self.handle)
+    @contextlib.contextmanager
+    def load_library(self, module, library=sys.executable, flags=0x2):
+        handle = module.LoadLibraryEx(library, 0, flags)
+        try:
+            yield handle
+        finally:
+            module.FreeLibrary(handle)
 
     def test_load_library_ex(self):
-        self.handle = self._load_library(win32api)
-        mini = self._load_library(pywin32.win32api)
-        self.assertEqual(mini, self.handle)
+        with self.load_library(win32api) as expected:
+            with self.load_library(self.module) as handle:
+                self.assertEqual(handle, expected)
 
         with self.assertRaises(error):
-            pywin32.win32api.LoadLibraryEx('ttt.dll', 0, 0x2)
+            self.module.LoadLibraryEx('ttt.dll', 0, 0x2)
 
     def test_free_library(self):
-        self.handle = self._load_library(win32api)
-        self.assertTrue(self._free_library(win32api, self.handle) is None)
-        self.assertNotEqual(
-            self._free_library(pywin32.win32api, self.handle), 0)
+        with self.load_library(win32api) as handle:
+            self.assertTrue(win32api.FreeLibrary(handle) is None)
+            self.assertNotEqual(self.module.FreeLibrary(handle), 0)
 
         with self.assertRaises(error):
-            self._free_library(pywin32.win32api, -3)
+            self.module.FreeLibrary(-3)
 
     def test_enum_resource_types(self):
-        self.handle = self._load_library(win32api, 'explorer.exe')
-        original = self._enum_resource_types(win32api, self.handle)
-        mini = self._enum_resource_types(pywin32.win32api, self.handle)
-        self.assertEqual(mini, original)
+        with self.load_library(win32api, 'explorer.exe') as handle:
+            expected = win32api.EnumResourceTypes(handle)
+
+        with self.load_library(pywin32.win32api, 'explorer.exe') as handle:
+            resource_types = pywin32.win32api.EnumResourceTypes(handle)
+
+        self.assertEqual(resource_types, expected)
 
         with self.assertRaises(error):
-            pywin32.win32api.EnumResourceTypes(-3)
+            self.module.EnumResourceTypes(-3)
 
     def test_enum_resource_names(self):
-        self.handle = self._load_library(win32api)
-        resource_types = self._enum_resource_types(win32api, self.handle)
-
-        for resource_type in resource_types:
-            original = self._enum_resource_names(
-                win32api, self.handle, resource_type)
-            mini = self._enum_resource_names(
-                pywin32.win32api, self.handle, resource_type)
-            self.assertEqual(mini, original)
+        with self.load_library(win32api, 'explorer.exe') as handle:
+            resource_types = win32api.EnumResourceTypes(handle)
+            for resource_type in resource_types:
+                expected = win32api.EnumResourceNames(handle, resource_type)
+                resource_names = self.module.EnumResourceNames(
+                    handle, resource_type)
+            self.assertEqual(resource_names, expected)
 
         with self.assertRaises(error):
-            pywin32.win32api.EnumResourceNames(2, 3)
+            self.module.EnumResourceNames(2, 3)
 
     def test_enum_resource_languages(self):
-        handle = self._load_library(win32api)
-        resource_types = self._enum_resource_types(win32api, handle)
-
-        for resource_type in resource_types:
-            resource_names = self._enum_resource_names(
-                win32api, handle, resource_type)
-            for resource_name in resource_names:
-                original = self._enum_resource_languages(
-                    win32api, handle, resource_type, resource_name)
-                mini = self._enum_resource_languages(
-                    pywin32.win32api, handle, resource_type,
-                    resource_name)
-                self.assertEqual(mini, original)
+        with self.load_library(win32api, 'explorer.exe') as handle:
+            resource_types = win32api.EnumResourceTypes(handle)
+            for resource_type in resource_types:
+                resource_names = win32api.EnumResourceNames(
+                    handle, resource_type)
+                for resource_name in resource_names:
+                    expected = win32api.EnumResourceLanguages(
+                        handle, resource_type, resource_name)
+                    resource_languages = self.module.EnumResourceLanguages(
+                        handle, resource_type, resource_name)
+                    self.assertEqual(resource_languages, expected)
 
         with self.assertRaises(error):
-            pywin32.win32api.EnumResourceLanguages(
-                handle, resource_type, 2235)
+            self.module.EnumResourceLanguages(handle, resource_type, 2235)
 
     def test_load_resource(self):
-        handle = self._load_library(win32api)
-        resource_types = self._enum_resource_types(win32api, handle)
-
-        for resource_type in resource_types:
-            resource_names = self._enum_resource_names(
-                win32api, handle, resource_type)
-            for resource_name in resource_names:
-                resource_languages = self._enum_resource_languages(
-                    win32api, handle, resource_type, resource_name)
-                for resource_language in resource_languages:
-                    original = self._load_resource(
-                        win32api, handle,
-                        resource_type, resource_name,
-                        resource_language)
-                    mini = self._load_resource(
-                        pywin32.win32api, handle,
-                        resource_type, resource_name,
-                        resource_language)
-                    self.assertEqual(mini, original)
+        with self.load_library(win32api, 'explorer.exe') as handle:
+            resource_types = win32api.EnumResourceTypes(handle)
+            for resource_type in resource_types:
+                resource_names = win32api.EnumResourceNames(
+                    handle, resource_type)
+                for resource_name in resource_names:
+                    resource_languages = win32api.EnumResourceLanguages(
+                        handle, resource_type, resource_name)
+                    for resource_language in resource_languages:
+                        expected = win32api.LoadResource(
+                            handle, resource_type, resource_name,
+                            resource_language)
+                        resource = self.module.LoadResource(
+                            handle, resource_type, resource_name,
+                            resource_language)
+                        self.assertEqual(resource, expected)
 
         with self.assertRaises(error):
-            pywin32.win32api.LoadResource(
+            self.module.LoadResource(
                 handle, resource_type, resource_name, 12435)
-
-    def _load_library(self, module, library=sys.executable):
-        # backward shim for win32api module which does not export
-        # LOAD_LIBRARY_AS_DATAFILE
-        LOAD_LIBRARY_AS_DATAFILE = getattr(
-            module, "LOAD_LIBRARY_AS_DATAFILE", 0x2)
-        return module.LoadLibraryEx(
-            library, 0, LOAD_LIBRARY_AS_DATAFILE)
-
-    def _free_library(self, module, handle):
-        return module.FreeLibrary(handle)
-
-    def _enum_resource_types(self, module, handle):
-        return module.EnumResourceTypes(handle)
-
-    def _enum_resource_names(self, module, handle, resource_type):
-        return module.EnumResourceNames(handle, resource_type)
-
-    def _enum_resource_languages(self, module, handle, resource_type, name):
-        return module.EnumResourceLanguages(handle, resource_type, name)
-
-    def _load_resource(
-            self, module, handle, resource_type,
-            resource_name, resource_language):
-        return module.LoadResource(
-            handle, resource_type, resource_name, resource_language)
 
 
 if __name__ == '__main__':

--- a/win32ctypes/tests/test_win32api.py
+++ b/win32ctypes/tests/test_win32api.py
@@ -45,10 +45,10 @@ class TestWin32API(compat.TestCase):
             self.module.FreeLibrary(-3)
 
     def test_enum_resource_types(self):
-        with self.load_library(win32api, 'explorer.exe') as handle:
+        with self.load_library(win32api, 'shell32.dll') as handle:
             expected = win32api.EnumResourceTypes(handle)
 
-        with self.load_library(pywin32.win32api, 'explorer.exe') as handle:
+        with self.load_library(pywin32.win32api, 'shell32.dll') as handle:
             resource_types = self.module.EnumResourceTypes(handle)
 
         self.assertEqual(resource_types, expected)
@@ -57,7 +57,7 @@ class TestWin32API(compat.TestCase):
             self.module.EnumResourceTypes(-3)
 
     def test_enum_resource_names(self):
-        with self.load_library(win32api, 'explorer.exe') as handle:
+        with self.load_library(win32api, 'shell32.dll') as handle:
             resource_types = win32api.EnumResourceTypes(handle)
             for resource_type in resource_types:
                 expected = win32api.EnumResourceNames(handle, resource_type)

--- a/win32ctypes/tests/test_win32api.py
+++ b/win32ctypes/tests/test_win32api.py
@@ -124,7 +124,7 @@ class TestWin32API(compat.TestCase):
         if hasattr(type_id, 'index'):
             return type_id
         else:
-            return u'#{}'.format(type_id)
+            return u'#{0}'.format(type_id)
 
 
 if __name__ == '__main__':

--- a/win32ctypes/tests/test_win32api.py
+++ b/win32ctypes/tests/test_win32api.py
@@ -114,7 +114,7 @@ class TestWin32API(compat.TestCase):
         LOAD_LIBRARY_AS_DATAFILE = getattr(
             module, "LOAD_LIBRARY_AS_DATAFILE", 0x2)
         return module.LoadLibraryEx(
-            sys.executable, 0, LOAD_LIBRARY_AS_DATAFILE)
+            'explorer.exe', 0, LOAD_LIBRARY_AS_DATAFILE)
 
     def _free_library(self, module, handle):
         return module.FreeLibrary(handle)

--- a/win32ctypes/tests/test_win32api.py
+++ b/win32ctypes/tests/test_win32api.py
@@ -49,7 +49,7 @@ class TestWin32API(compat.TestCase):
             expected = win32api.EnumResourceTypes(handle)
 
         with self.load_library(pywin32.win32api, 'explorer.exe') as handle:
-            resource_types = pywin32.win32api.EnumResourceTypes(handle)
+            resource_types = self.module.EnumResourceTypes(handle)
 
         self.assertEqual(resource_types, expected)
 

--- a/win32ctypes/tests/test_win32api.py
+++ b/win32ctypes/tests/test_win32api.py
@@ -42,7 +42,7 @@ class TestWin32API(compat.TestCase):
             self._free_library(pywin32.win32api, -3)
 
     def test_enum_resource_types(self):
-        self.handle = self._load_library(win32api)
+        self.handle = self._load_library(win32api, 'explorer.exe')
         original = self._enum_resource_types(win32api, self.handle)
         mini = self._enum_resource_types(pywin32.win32api, self.handle)
         self.assertEqual(mini, original)
@@ -108,13 +108,13 @@ class TestWin32API(compat.TestCase):
             pywin32.win32api.LoadResource(
                 handle, resource_type, resource_name, 12435)
 
-    def _load_library(self, module):
+    def _load_library(self, module, library=sys.executable):
         # backward shim for win32api module which does not export
         # LOAD_LIBRARY_AS_DATAFILE
         LOAD_LIBRARY_AS_DATAFILE = getattr(
             module, "LOAD_LIBRARY_AS_DATAFILE", 0x2)
         return module.LoadLibraryEx(
-            'explorer.exe', 0, LOAD_LIBRARY_AS_DATAFILE)
+            library, 0, LOAD_LIBRARY_AS_DATAFILE)
 
     def _free_library(self, module, handle):
         return module.FreeLibrary(handle)

--- a/win32ctypes/tests/test_win32api.py
+++ b/win32ctypes/tests/test_win32api.py
@@ -45,10 +45,10 @@ class TestWin32API(compat.TestCase):
             self.module.FreeLibrary(-3)
 
     def test_enum_resource_types(self):
-        with self.load_library(win32api, 'shell32.dll') as handle:
+        with self.load_library(win32api, u'shell32.dll') as handle:
             expected = win32api.EnumResourceTypes(handle)
 
-        with self.load_library(pywin32.win32api, 'shell32.dll') as handle:
+        with self.load_library(pywin32.win32api, u'shell32.dll') as handle:
             resource_types = self.module.EnumResourceTypes(handle)
 
         self.assertEqual(resource_types, expected)
@@ -57,19 +57,23 @@ class TestWin32API(compat.TestCase):
             self.module.EnumResourceTypes(-3)
 
     def test_enum_resource_names(self):
-        with self.load_library(win32api, 'shell32.dll') as handle:
+        with self.load_library(win32api, u'shell32.dll') as handle:
             resource_types = win32api.EnumResourceTypes(handle)
             for resource_type in resource_types:
                 expected = win32api.EnumResourceNames(handle, resource_type)
                 resource_names = self.module.EnumResourceNames(
                     handle, resource_type)
-            self.assertEqual(resource_names, expected)
+                self.assertEqual(resource_names, expected)
+                # check that the #<index> format works
+                resource_names = self.module.EnumResourceNames(
+                    handle, self._id2str(resource_type))
+                self.assertEqual(resource_names, expected)
 
         with self.assertRaises(error):
             self.module.EnumResourceNames(2, 3)
 
     def test_enum_resource_languages(self):
-        with self.load_library(win32api, 'explorer.exe') as handle:
+        with self.load_library(win32api, u'shell32.dll') as handle:
             resource_types = win32api.EnumResourceTypes(handle)
             for resource_type in resource_types:
                 resource_names = win32api.EnumResourceNames(
@@ -80,12 +84,17 @@ class TestWin32API(compat.TestCase):
                     resource_languages = self.module.EnumResourceLanguages(
                         handle, resource_type, resource_name)
                     self.assertEqual(resource_languages, expected)
+                    # check that the #<index> format works
+                    resource_languages = self.module.EnumResourceLanguages(
+                        handle, self._id2str(resource_type),
+                        self._id2str(resource_name))
+                    self.assertEqual(resource_languages, expected)
 
         with self.assertRaises(error):
             self.module.EnumResourceLanguages(handle, resource_type, 2235)
 
     def test_load_resource(self):
-        with self.load_library(win32api, 'explorer.exe') as handle:
+        with self.load_library(win32api, u'explorer.exe') as handle:
             resource_types = win32api.EnumResourceTypes(handle)
             for resource_type in resource_types:
                 resource_names = win32api.EnumResourceNames(
@@ -100,11 +109,22 @@ class TestWin32API(compat.TestCase):
                         resource = self.module.LoadResource(
                             handle, resource_type, resource_name,
                             resource_language)
+                        # check that the #<index> format works
+                        resource = self.module.LoadResource(
+                            handle, self._id2str(resource_type),
+                            self._id2str(resource_name),
+                            resource_language)
                         self.assertEqual(resource, expected)
 
         with self.assertRaises(error):
             self.module.LoadResource(
                 handle, resource_type, resource_name, 12435)
+
+    def _id2str(self, type_id):
+        if hasattr(type_id, 'index'):
+            return type_id
+        else:
+            return u'#{}'.format(type_id)
 
 
 if __name__ == '__main__':

--- a/win32ctypes/tests/test_win32api.py
+++ b/win32ctypes/tests/test_win32api.py
@@ -34,7 +34,7 @@ class TestWin32API(compat.TestCase):
                 self.assertEqual(handle, expected)
 
         with self.assertRaises(error):
-            self.module.LoadLibraryEx('ttt.dll', 0, 0x2)
+            self.module.LoadLibraryEx(u'ttt.dll', 0, 0x2)
 
     def test_free_library(self):
         with self.load_library(win32api) as handle:


### PR DESCRIPTION
This PR fixes #21 

The problem was that the callback functions receive the resource type and resource name as a pointer to wchar. But the value of the pointer passes the `IS_INTRESOURCE` check that it is interprated as an integer index inastead of a string (see https://msdn.microsoft.com/en-us/library/windows/desktop/ms648041%28v=vs.85%29.aspx)

The solutiuon is to claim the input types are LPVOID and wrap the user provided callback in order to convert them into python frieadly types. This results in similar output with the origin win32api library.

The error was not visible before because the `python.exe`does not have resource types defined by name. I have use alternative files that should exist on all windows platforms.
