### PR TITLE
Make PyPI link to GitHub

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,7 @@ with open(filename, 'w') as handle:
 setup(
     name='pywin32-ctypes',
     version=version,
+    url='https://github.com/enthought/pywin32-ctypes',
     author='Enthought Inc',
     author_email='info@enthought.com',
     packages=find_packages(),


### PR DESCRIPTION
Adds a home page link to PyPI metadata, so that people don't have to google.