### PR TITLE
API additions to allow pywin32-ctypes to work with pyinstaller

### DIFF
--- a/win32ctypes/core/cffi/_kernel32.py
+++ b/win32ctypes/core/cffi/_kernel32.py
@@ -36,6 +36,12 @@ DWORD WINAPI SizeofResource(HMODULE hModule, HRSRC hResInfo);
 HGLOBAL WINAPI LoadResource(HMODULE hModule, HRSRC hResInfo);
 LPVOID WINAPI LockResource(HGLOBAL hResData);
 
+HANDLE WINAPI BeginUpdateResourceW(LPCTSTR pFileName, BOOL bDeleteExistingResources);
+BOOL WINAPI EndUpdateResourceW(HANDLE hUpdate, BOOL fDiscard);
+BOOL WINAPI UpdateResourceW(HANDLE  hUpdate, LPCTSTR lpType, LPCTSTR lpName, WORD wLanguage, LPVOID lpData, DWORD cbData);
+UINT WINAPI GetWindowsDirectoryW(LPTSTR lpBuffer, UINT uSize);
+UINT WINAPI GetSystemDirectoryW(LPTSTR lpBuffer, UINT uSize);
+
 """)
 
 kernel32 = ffi.dlopen('kernel32.dll')
@@ -64,6 +70,18 @@ def ENUMRESLANGPROC(callback):
 
 def _GetACP():
     return kernel32.GetACP()
+
+
+def _GetWindowsDirectory():
+    buffer = ffi.new('wchar_t[256]')
+    l = kernel32.GetWindowsDirectoryW(buffer, 256)
+    return ffi.unpack(buffer, l)
+
+
+def _GetSystemDirectory():
+    buffer = ffi.new('wchar_t[256]')
+    l = kernel32.GetSystemDirectoryW(buffer, 256)
+    return ffi.unpack(buffer, l)
 
 
 def _GetTickCount():
@@ -118,3 +136,22 @@ def _LoadResource(hModule, hResInfo):
 
 def _LockResource(hResData):
     return check_null(kernel32.LockResource(hResData))
+
+
+def _BeginUpdateResource(pFileName, bDeleteExistingResources):
+    return check_null(
+        kernel32.BeginUpdateResourceW(unicode(pFileName),
+                                      bDeleteExistingResources))
+
+
+def _EndUpdateResource(hUpdate, fDiscard):
+    check_zero(kernel32.EndUpdateResourceW(PVOID(hUpdate), fDiscard))
+
+
+def _UpdateResource(hUpdate, lpType, lpName, wLanguage, lpData, cbData):
+    return check_null(
+        kernel32.UpdateResourceW(PVOID(hUpdate), unicode(lpType),
+                                 unicode(lpName), wLanguage, PVOID(lpData),
+                                 cbData))
+
+

--- a/win32ctypes/core/cffi/_kernel32.py
+++ b/win32ctypes/core/cffi/_kernel32.py
@@ -10,6 +10,10 @@ from __future__ import absolute_import
 from ._util import (
     ffi, check_null, check_zero, HMODULE, PVOID, RESOURCE, resource)
 
+# TODO: retrieve this value using ffi
+MAX_PATH = 260
+MAX_PATH_BUF = 'wchar_t[%s]' % MAX_PATH
+
 ffi.cdef("""
 
 typedef int WINBOOL;
@@ -73,14 +77,14 @@ def _GetACP():
 
 
 def _GetWindowsDirectory():
-    buffer = ffi.new('wchar_t[256]')
-    l = kernel32.GetWindowsDirectoryW(buffer, 256)
+    buffer = ffi.new(MAX_PATH_BUF)
+    l = kernel32.GetWindowsDirectoryW(buffer, MAX_PATH)
     return ffi.unpack(buffer, l)
 
 
 def _GetSystemDirectory():
-    buffer = ffi.new('wchar_t[256]')
-    l = kernel32.GetSystemDirectoryW(buffer, 256)
+    buffer = ffi.new(MAX_PATH_BUF)
+    l = kernel32.GetSystemDirectoryW(buffer, MAX_PATH)
     return ffi.unpack(buffer, l)
 
 

--- a/win32ctypes/core/ctypes/_kernel32.py
+++ b/win32ctypes/core/ctypes/_kernel32.py
@@ -10,7 +10,7 @@ from __future__ import absolute_import
 import ctypes
 from ctypes.wintypes import (
     BOOL, DWORD, HANDLE, HMODULE, LPCWSTR, WORD, HRSRC,
-    HGLOBAL, LPVOID, UINT)
+    HGLOBAL, LPVOID, UINT, LPWSTR, MAX_PATH)
 
 from ._common import LONG_PTR, IS_INTRESOURCE
 from ._util import check_null, check_zero, function_factory
@@ -123,6 +123,54 @@ _GetTickCount = function_factory(
     kernel32.GetTickCount,
     None,
     DWORD)
+
+_BeginUpdateResource = function_factory(
+    kernel32.BeginUpdateResourceW,
+    [LPCWSTR, BOOL],
+    HANDLE,
+    check_null)
+
+_EndUpdateResource = function_factory(
+    kernel32.EndUpdateResourceW,
+    [HANDLE, BOOL],
+    BOOL,
+    check_zero)
+
+_BaseUpdateResource = function_factory(
+    kernel32.UpdateResourceW,
+    [HANDLE, LPCWSTR, LPCWSTR, WORD, LPVOID, DWORD],
+    BOOL,
+    check_zero)
+
+_BaseGetWindowsDirectory = function_factory(
+    kernel32.GetWindowsDirectoryW,
+    [LPWSTR, UINT],
+    UINT,
+    check_zero)
+
+_BaseGetSystemDirectory = function_factory(
+    kernel32.GetSystemDirectoryW,
+    [LPWSTR, UINT],
+    UINT,
+    check_zero)
+
+
+def _GetWindowsDirectory():
+    buffer = ctypes.create_unicode_buffer(MAX_PATH)
+    _BaseGetWindowsDirectory(buffer, MAX_PATH)
+    return ctypes.cast(buffer, LPCWSTR).value
+
+
+def _GetSystemDirectory():
+    buffer = ctypes.create_unicode_buffer(MAX_PATH)
+    _BaseGetSystemDirectory(buffer, MAX_PATH)
+    return ctypes.cast(buffer, LPCWSTR).value
+
+
+def _UpdateResource(hUpdate, lpType, lpName, wLanguage, lpData, cbData):
+    lp_type = LPCWSTR(lpType)
+    lp_name = LPCWSTR(lpName)
+    return _BaseUpdateResource(hUpdate, lp_type, lp_name, wLanguage, lpData, cbData)
 
 
 def _EnumResourceNames(hModule, lpszType, lpEnumFunc, lParam):

--- a/win32ctypes/pywin32/win32api.py
+++ b/win32ctypes/pywin32/win32api.py
@@ -206,3 +206,28 @@ def FreeLibrary(hModule):
 
 def GetTickCount():
     return _kernel32._GetTickCount()
+
+
+def BeginUpdateResource(pFileName, bDeleteExistingResources):
+    with _pywin32error():
+        return _kernel32._BeginUpdateResource(pFileName, bDeleteExistingResources)
+
+
+def EndUpdateResource(hUpdate, fDiscard):
+    with _pywin32error():
+        return _kernel32._EndUpdateResource(hUpdate, fDiscard)
+
+
+def UpdateResource(hUpdate, lpType, lpName, lpData, wLanguage):
+    with _pywin32error():
+        return _kernel32._UpdateResource(hUpdate, lpType, lpName, wLanguage, lpData, len(lpData))
+
+
+def GetWindowsDirectory():
+    with _pywin32error():
+        return _kernel32._GetWindowsDirectory()
+
+
+def GetSystemDirectory():
+    with _pywin32error():
+        return _kernel32._GetSystemDirectory()

--- a/win32ctypes/tests/test_win32api.py
+++ b/win32ctypes/tests/test_win32api.py
@@ -130,6 +130,13 @@ class TestWin32API(compat.TestCase):
         else:
             return u'#{0}'.format(type_id)
 
+    def test_get_windows_directory(self):
+        self.assertEqual(self.module.GetWindowsDirectory().lower(), r"c:\windows")
+        
+    def test_get_system_directory(self):
+        self.assertEqual(self.module.GetSystemDirectory().lower(),
+                         r"c:\windows\system32")
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Our goal is to use pyinstaller in msys2 environment, and cffi/pywin32 don't work in msys2 so ctypes is our primary focus.

* Adds minimal set of APIs to allow pyinstaller to work correctly
* The ctypes api has been used successfully with pyinstaller, the cffi stuff I threw in for completeness

CC @dangmai

