### PR TITLE
pywin32 returns strings on Python 2.7 (not unicode)

### DIFF
--- a/win32ctypes/pywin32/win32api.py
+++ b/win32ctypes/pywin32/win32api.py
@@ -231,9 +231,11 @@ def UpdateResource(hUpdate, lpType, lpName, lpData, wLanguage):
 
 def GetWindowsDirectory():
     with _pywin32error():
-        return _kernel32._GetWindowsDirectory()
+        # Note: pywin32 returns str on py27, unicode (which is str) on py3
+        return str(_kernel32._GetWindowsDirectory())
 
 
 def GetSystemDirectory():
     with _pywin32error():
-        return _kernel32._GetSystemDirectory()
+        # Note: pywin32 returns str on py27, unicode (which is str) on py3
+        return str(_kernel32._GetSystemDirectory())

--- a/win32ctypes/tests/test_win32api.py
+++ b/win32ctypes/tests/test_win32api.py
@@ -130,12 +130,17 @@ class TestWin32API(compat.TestCase):
         else:
             return u'#{0}'.format(type_id)
 
+    # note: pywin32 returns str on py27, unicode (which is str) on py3
+
     def test_get_windows_directory(self):
-        self.assertEqual(self.module.GetWindowsDirectory().lower(), r"c:\windows")
+        r = self.module.GetWindowsDirectory()
+        self.assertTrue(isinstance(r, str))
+        self.assertEqual(r.lower(), r"c:\windows")
         
     def test_get_system_directory(self):
-        self.assertEqual(self.module.GetSystemDirectory().lower(),
-                         r"c:\windows\system32")
+        r = self.module.GetSystemDirectory()
+        self.assertTrue(isinstance(r, str))
+        self.assertEqual(r.lower(), r"c:\windows\system32")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This only applies when PyWinObject_FromTCHAR is used.

See https://github.com/pywin32/pypiwin32/blob/master/win32/src/PyWinTypes.h#L358