### PR TITLE
[WIP] Fix Resource functions issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,10 @@ python:
 
 env:
   - BITS=32
+    SKIP_WINE_KNOWN_FAILURES=1
 
 # The pywin32-219 installers for python 2.6 64bit are missing files.
-# 64-bit for 2.7, 3.3 and 3.4 are tested with appveyor.
+# 64-bit for 2.7, 3.5 and 3.6 are tested with appveyor.
 
 before_install:
   - sudo add-apt-repository ppa:ubuntu-wine/ppa -y

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ python:
 
 env:
   - BITS=32
-#    SKIP_WINE_KNOWN_FAILURES=1
+    SKIP_WINE_KNOWN_FAILURES=1
 
 # The pywin32-219 installers for python 2.6 64bit are missing files.
 # 64-bit for 2.7, 3.5 and 3.6 are tested with appveyor.

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ python:
 
 env:
   - BITS=32
-    SKIP_WINE_KNOWN_FAILURES=1
+#    SKIP_WINE_KNOWN_FAILURES=1
 
 # The pywin32-219 installers for python 2.6 64bit are missing files.
 # 64-bit for 2.7, 3.5 and 3.6 are tested with appveyor.

--- a/win32ctypes/core/__init__.py
+++ b/win32ctypes/core/__init__.py
@@ -7,16 +7,16 @@
 #
 from __future__ import absolute_import
 
+__all__ = ['_kernel32', '_advapi32', '_winerrors', '_common']
+
+from . import _winerrors
+
 try:
     import cffi
 except ImportError:
-    from win32ctypes.core.ctypes import _advapi32, _common, _kernel32
+    from .ctypes import _advapi32, _common, _kernel32
     _backend = 'ctypes'
 else:
-    from win32ctypes.core.cffi import _advapi32, _common, _kernel32
+    from .cffi import _advapi32, _common, _kernel32
     del cffi
     _backend = 'cffi'
-
-from win32ctypes.core import _winerrors
-
-__all__ = ['_kernel32', '_advapi32', '_winerrors', '_common']

--- a/win32ctypes/core/cffi/_kernel32.py
+++ b/win32ctypes/core/cffi/_kernel32.py
@@ -168,10 +168,10 @@ def _EndUpdateResource(hUpdate, fDiscard):
         function_name='EndUpdateResource')
 
 
-def _UpdateResource(hUpdate, lpType, lpName, wLanguage, cData):
-    cpData = ffi.from_buffer(cData)
+def _UpdateResource(hUpdate, lpType, lpName, wLanguage, cData, cbData):
+    lpData = ffi.from_buffer(cData)
     check_false(
         kernel32.UpdateResourceW(
             PVOID(hUpdate), RESOURCE(lpType), RESOURCE(lpName),
-            wLanguage, PVOID(cpData), len(cpData)),
+            wLanguage, PVOID(lpData), cbData),
         function_name='UpdateResource')

--- a/win32ctypes/core/cffi/_kernel32.py
+++ b/win32ctypes/core/cffi/_kernel32.py
@@ -142,6 +142,7 @@ def _SizeofResource(hModule, hResInfo):
         kernel32.SizeofResource(PVOID(hModule), hResInfo),
         function_name='SizeofResource')
 
+
 def _LoadResource(hModule, hResInfo):
     return check_null(
         kernel32.LoadResource(PVOID(hModule), hResInfo),
@@ -166,9 +167,10 @@ def _EndUpdateResource(hUpdate, fDiscard):
         function_name='EndUpdateResource')
 
 
-def _UpdateResource(hUpdate, lpType, lpName, wLanguage, lpData, cbData):
+def _UpdateResource(hUpdate, lpType, lpName, wLanguage, cData):
+    cpData = ffi.from_buffer(cData)
     check_false(
         kernel32.UpdateResourceW(
             PVOID(hUpdate), RESOURCE(lpType), RESOURCE(lpName),
-            wLanguage, PVOID(lpData), cbData),
+            wLanguage, PVOID(cpData), len(cpData)),
         function_name='UpdateResource')

--- a/win32ctypes/core/cffi/_kernel32.py
+++ b/win32ctypes/core/cffi/_kernel32.py
@@ -101,21 +101,21 @@ def _LoadLibraryEx(lpFilename, hFile, dwFlags):
 
 
 def _FreeLibrary(hModule):
-    return check_false(
+    check_false(
         kernel32.FreeLibrary(PVOID(hModule)),
         function_name='FreeLibrary')
 
 
 def _EnumResourceTypes(hModule, lpEnumFunc, lParam):
     callback = ffi.callback('ENUMRESTYPEPROC', lpEnumFunc)
-    return check_false(
+    check_false(
         kernel32.EnumResourceTypesW(PVOID(hModule), callback, lParam),
         function_name='EnumResourceTypes')
 
 
 def _EnumResourceNames(hModule, lpszType, lpEnumFunc, lParam):
     callback = ffi.callback('ENUMRESNAMEPROC', lpEnumFunc)
-    return check_false(
+    check_false(
         kernel32.EnumResourceNamesW(
             PVOID(hModule), RESOURCE(lpszType), callback, lParam),
         function_name='EnumResourceNames')
@@ -123,7 +123,7 @@ def _EnumResourceNames(hModule, lpszType, lpEnumFunc, lParam):
 
 def _EnumResourceLanguages(hModule, lpType, lpName, lpEnumFunc, lParam):
     callback = ffi.callback('ENUMRESLANGPROC', lpEnumFunc)
-    return check_false(
+    check_false(
         kernel32.EnumResourceLanguagesW(
             PVOID(hModule), RESOURCE(lpType),
             RESOURCE(lpName), callback, lParam),

--- a/win32ctypes/core/cffi/_kernel32.py
+++ b/win32ctypes/core/cffi/_kernel32.py
@@ -95,25 +95,30 @@ def _GetTickCount():
 def _LoadLibraryEx(lpFilename, hFile, dwFlags):
     result = check_null(
         kernel32.LoadLibraryExW(
-            unicode(lpFilename), ffi.NULL, dwFlags))
+            unicode(lpFilename), ffi.NULL, dwFlags),
+        function_name='LoadLibraryEx')
     return HMODULE(result)
 
 
 def _FreeLibrary(hModule):
-    return check_false(kernel32.FreeLibrary(PVOID(hModule)))
+    return check_false(
+        kernel32.FreeLibrary(PVOID(hModule)),
+        function_name='FreeLibrary')
 
 
 def _EnumResourceTypes(hModule, lpEnumFunc, lParam):
     callback = ffi.callback('ENUMRESTYPEPROC', lpEnumFunc)
     return check_false(
-        kernel32.EnumResourceTypesW(PVOID(hModule), callback, lParam))
+        kernel32.EnumResourceTypesW(PVOID(hModule), callback, lParam),
+        function_name='EnumResourceTypes')
 
 
 def _EnumResourceNames(hModule, lpszType, lpEnumFunc, lParam):
     callback = ffi.callback('ENUMRESNAMEPROC', lpEnumFunc)
     return check_false(
         kernel32.EnumResourceNamesW(
-            PVOID(hModule), RESOURCE(lpszType), callback, lParam))
+            PVOID(hModule), RESOURCE(lpszType), callback, lParam),
+        function_name='EnumResourceNames')
 
 
 def _EnumResourceLanguages(hModule, lpType, lpName, lpEnumFunc, lParam):
@@ -121,25 +126,32 @@ def _EnumResourceLanguages(hModule, lpType, lpName, lpEnumFunc, lParam):
     return check_false(
         kernel32.EnumResourceLanguagesW(
             PVOID(hModule), RESOURCE(lpType),
-            RESOURCE(lpName), callback, lParam))
+            RESOURCE(lpName), callback, lParam),
+        function_name='EnumResourceLanguages')
 
 
 def _FindResourceEx(hModule, lpType, lpName, wLanguage):
     return check_null(
         kernel32.FindResourceExW(
-            PVOID(hModule), RESOURCE(lpType), RESOURCE(lpName), wLanguage))
+            PVOID(hModule), RESOURCE(lpType), RESOURCE(lpName), wLanguage),
+        function_name='FindResourceEx')
 
 
 def _SizeofResource(hModule, hResInfo):
-    return check_zero(kernel32.SizeofResource(PVOID(hModule), hResInfo))
-
+    return check_zero(
+        kernel32.SizeofResource(PVOID(hModule), hResInfo),
+        function_name='SizeofResource')
 
 def _LoadResource(hModule, hResInfo):
-    return check_null(kernel32.LoadResource(PVOID(hModule), hResInfo))
+    return check_null(
+        kernel32.LoadResource(PVOID(hModule), hResInfo),
+        function_name='LoadResource')
 
 
 def _LockResource(hResData):
-    return check_null(kernel32.LockResource(hResData))
+    return check_null(
+        kernel32.LockResource(hResData),
+        function_name='LockResource')
 
 
 def _BeginUpdateResource(pFileName, bDeleteExistingResources):
@@ -149,11 +161,14 @@ def _BeginUpdateResource(pFileName, bDeleteExistingResources):
 
 
 def _EndUpdateResource(hUpdate, fDiscard):
-    return check_false(kernel32.EndUpdateResourceW(PVOID(hUpdate), fDiscard))
+    return check_false(
+        kernel32.EndUpdateResourceW(PVOID(hUpdate), fDiscard),
+        function_name='EndUpdateResource')
 
 
 def _UpdateResource(hUpdate, lpType, lpName, wLanguage, lpData, cbData):
     return check_false(
         kernel32.UpdateResourceW(
             PVOID(hUpdate), RESOURCE(lpType), RESOURCE(lpName),
-            wLanguage, PVOID(lpData), cbData))
+            wLanguage, PVOID(lpData), cbData),
+        function_name='UpdateResource')

--- a/win32ctypes/core/cffi/_kernel32.py
+++ b/win32ctypes/core/cffi/_kernel32.py
@@ -100,25 +100,25 @@ def _LoadLibraryEx(lpFilename, hFile, dwFlags):
 
 
 def _FreeLibrary(hModule):
-    check_zero(kernel32.FreeLibrary(PVOID(hModule)))
+    return check_false(kernel32.FreeLibrary(PVOID(hModule)))
 
 
 def _EnumResourceTypes(hModule, lpEnumFunc, lParam):
     callback = ffi.callback('ENUMRESTYPEPROC', lpEnumFunc)
-    check_zero(
+    return check_false(
         kernel32.EnumResourceTypesW(PVOID(hModule), callback, lParam))
 
 
 def _EnumResourceNames(hModule, lpszType, lpEnumFunc, lParam):
     callback = ffi.callback('ENUMRESNAMEPROC', lpEnumFunc)
-    check_zero(
+    return check_false(
         kernel32.EnumResourceNamesW(
             PVOID(hModule), RESOURCE(lpszType), callback, lParam))
 
 
 def _EnumResourceLanguages(hModule, lpType, lpName, lpEnumFunc, lParam):
     callback = ffi.callback('ENUMRESLANGPROC', lpEnumFunc)
-    check_zero(
+    return check_false(
         kernel32.EnumResourceLanguagesW(
             PVOID(hModule), RESOURCE(lpType),
             RESOURCE(lpName), callback, lParam))

--- a/win32ctypes/core/cffi/_kernel32.py
+++ b/win32ctypes/core/cffi/_kernel32.py
@@ -156,9 +156,10 @@ def _LockResource(hResData):
 
 
 def _BeginUpdateResource(pFileName, bDeleteExistingResources):
-    return check_null(
+    result = check_null(
         kernel32.BeginUpdateResourceW(
             unicode(pFileName), bDeleteExistingResources))
+    return HMODULE(result)
 
 
 def _EndUpdateResource(hUpdate, fDiscard):

--- a/win32ctypes/core/cffi/_kernel32.py
+++ b/win32ctypes/core/cffi/_kernel32.py
@@ -144,18 +144,16 @@ def _LockResource(hResData):
 
 def _BeginUpdateResource(pFileName, bDeleteExistingResources):
     return check_null(
-        kernel32.BeginUpdateResourceW(unicode(pFileName),
-                                      bDeleteExistingResources))
+        kernel32.BeginUpdateResourceW(
+            unicode(pFileName), bDeleteExistingResources))
 
 
 def _EndUpdateResource(hUpdate, fDiscard):
-    check_zero(kernel32.EndUpdateResourceW(PVOID(hUpdate), fDiscard))
+    return check_zero(kernel32.EndUpdateResourceW(PVOID(hUpdate), fDiscard))
 
 
 def _UpdateResource(hUpdate, lpType, lpName, wLanguage, lpData, cbData):
-    return check_null(
-        kernel32.UpdateResourceW(PVOID(hUpdate), unicode(lpType),
-                                 unicode(lpName), wLanguage, PVOID(lpData),
-                                 cbData))
-
-
+    return check_zero(
+        kernel32.UpdateResourceW(
+            PVOID(hUpdate), RESOURCE(lpType), RESOURCE(lpName),
+            wLanguage, PVOID(lpData), cbData))

--- a/win32ctypes/core/cffi/_kernel32.py
+++ b/win32ctypes/core/cffi/_kernel32.py
@@ -161,13 +161,13 @@ def _BeginUpdateResource(pFileName, bDeleteExistingResources):
 
 
 def _EndUpdateResource(hUpdate, fDiscard):
-    return check_false(
+    check_false(
         kernel32.EndUpdateResourceW(PVOID(hUpdate), fDiscard),
         function_name='EndUpdateResource')
 
 
 def _UpdateResource(hUpdate, lpType, lpName, wLanguage, lpData, cbData):
-    return check_false(
+    check_false(
         kernel32.UpdateResourceW(
             PVOID(hUpdate), RESOURCE(lpType), RESOURCE(lpName),
             wLanguage, PVOID(lpData), cbData),

--- a/win32ctypes/core/cffi/_kernel32.py
+++ b/win32ctypes/core/cffi/_kernel32.py
@@ -8,7 +8,7 @@
 from __future__ import absolute_import
 
 from ._util import (
-    ffi, check_null, check_zero, HMODULE, PVOID, RESOURCE, resource)
+    ffi, check_null, check_zero, check_false, HMODULE, PVOID, RESOURCE, resource)
 
 # TODO: retrieve this value using ffi
 MAX_PATH = 260
@@ -149,11 +149,11 @@ def _BeginUpdateResource(pFileName, bDeleteExistingResources):
 
 
 def _EndUpdateResource(hUpdate, fDiscard):
-    return check_zero(kernel32.EndUpdateResourceW(PVOID(hUpdate), fDiscard))
+    return check_false(kernel32.EndUpdateResourceW(PVOID(hUpdate), fDiscard))
 
 
 def _UpdateResource(hUpdate, lpType, lpName, wLanguage, lpData, cbData):
-    return check_zero(
+    return check_false(
         kernel32.UpdateResourceW(
             PVOID(hUpdate), RESOURCE(lpType), RESOURCE(lpName),
             wLanguage, PVOID(lpData), cbData))

--- a/win32ctypes/core/cffi/_util.py
+++ b/win32ctypes/core/cffi/_util.py
@@ -53,9 +53,27 @@ def resource(lpRESOURCEID):
 
 
 class ErrorWhen(object):
+    """ Callable factory for raising errors when calling cffi functions.
 
-    def __init__(self, check):
+    """
+
+    def __init__(self, check, raise_on_zero=True):
+        """ Constructor
+
+        Parameters
+        ----------
+        check :
+            The return value that designates that an error has taken place.
+
+        raise_on_zero : bool
+            When set any error will be raised. When false the winerror
+            is checked and only non-zero win errors are raised. Currently
+            this parameters is used to workaround issues with the win32
+            implementation in ``wine``.
+
+        """
         self._check = check
+        self._raise_on_zero = raise_on_zero
 
     def __call__(self, value, function_name=''):
         if value == self._check:
@@ -65,6 +83,8 @@ class ErrorWhen(object):
 
     def _raise_error(self, function_name=''):
         code, message = ffi.getwinerror()
+        if not self._raise_on_zero and code == 0:
+            return
         exception = WindowsError()
         exception.errno = ffi.errno
         exception.winerror = code
@@ -72,6 +92,7 @@ class ErrorWhen(object):
         exception.function = function_name
         raise exception
 
+
 check_null = ErrorWhen(ffi.NULL)
 check_zero = ErrorWhen(0)
-check_false = ErrorWhen(False)
+check_false = ErrorWhen(False, raise_on_zero=True)

--- a/win32ctypes/core/cffi/_util.py
+++ b/win32ctypes/core/cffi/_util.py
@@ -83,8 +83,6 @@ class ErrorWhen(object):
 
     def _raise_error(self, function_name=''):
         code, message = ffi.getwinerror()
-        if not self._raise_on_zero and code == 0:
-            return
         exception = WindowsError()
         exception.errno = ffi.errno
         exception.winerror = code
@@ -95,4 +93,4 @@ class ErrorWhen(object):
 
 check_null = ErrorWhen(ffi.NULL)
 check_zero = ErrorWhen(0)
-check_false = ErrorWhen(False, raise_on_zero=True)
+check_false = ErrorWhen(False)

--- a/win32ctypes/core/cffi/_util.py
+++ b/win32ctypes/core/cffi/_util.py
@@ -74,3 +74,4 @@ class ErrorWhen(object):
 
 check_null = ErrorWhen(ffi.NULL)
 check_zero = ErrorWhen(0)
+check_false = ErrorWhen(False)

--- a/win32ctypes/core/ctypes/_common.py
+++ b/win32ctypes/core/ctypes/_common.py
@@ -9,7 +9,9 @@ from __future__ import absolute_import
 
 import ctypes
 import sys
-from ctypes import pythonapi, POINTER, c_void_p, py_object, c_char_p
+from ctypes import (
+    pythonapi, POINTER, c_void_p, py_object, c_char_p, c_int, c_long, c_int64,
+    c_longlong)
 from ctypes import cast  # noqa imported here for convenience
 from ctypes.wintypes import BYTE
 
@@ -19,12 +21,12 @@ from ._util import function_factory
 PPy_UNICODE = c_void_p
 LPBYTE = POINTER(BYTE)
 is_64bits = sys.maxsize > 2**32
-Py_ssize_t = ctypes.c_int64 if is_64bits else ctypes.c_int
+Py_ssize_t = c_int64 if is_64bits else c_int
 
-if ctypes.sizeof(ctypes.c_long) == ctypes.sizeof(ctypes.c_void_p):
-    LONG_PTR = ctypes.c_long
-elif ctypes.sizeof(ctypes.c_longlong) == ctypes.sizeof(ctypes.c_void_p):
-    LONG_PTR = ctypes.c_longlong
+if ctypes.sizeof(c_long) == ctypes.sizeof(c_void_p):
+    LONG_PTR = c_long
+elif ctypes.sizeof(c_longlong) == ctypes.sizeof(c_void_p):
+    LONG_PTR = c_longlong
 
 if PY3:
     _PyBytes_FromStringAndSize = function_factory(

--- a/win32ctypes/core/ctypes/_common.py
+++ b/win32ctypes/core/ctypes/_common.py
@@ -9,7 +9,8 @@ from __future__ import absolute_import
 
 import ctypes
 import sys
-from ctypes import pythonapi, POINTER, c_void_p, py_object, c_char_p, cast
+from ctypes import pythonapi, POINTER, c_void_p, py_object, c_char_p
+from ctypes import cast  # noqa imported here for convenience
 from ctypes.wintypes import BYTE
 
 from win32ctypes.core.compat import PY3

--- a/win32ctypes/core/ctypes/_kernel32.py
+++ b/win32ctypes/core/ctypes/_kernel32.py
@@ -107,7 +107,7 @@ _BaseEnumResourceNames = function_factory(
     kernel32.EnumResourceNamesW,
     [HMODULE, LPCWSTR, _ENUMRESNAMEPROC, LONG_PTR],
     BOOL,
-    check_zero)
+    check_false)
 
 _BaseEnumResourceLanguages = function_factory(
     kernel32.EnumResourceLanguagesW,
@@ -172,20 +172,19 @@ def _GetSystemDirectory():
 def _UpdateResource(hUpdate, lpType, lpName, wLanguage, lpData, cbData):
     lp_type = LPCWSTR(lpType)
     lp_name = LPCWSTR(lpName)
-    return _BaseUpdateResource(
+    _BaseUpdateResource(
         hUpdate, lp_type, lp_name, wLanguage, lpData, cbData)
 
 
 def _EnumResourceNames(hModule, lpszType, lpEnumFunc, lParam):
     resource_type = LPCWSTR(lpszType)
-    return _BaseEnumResourceNames(
-        hModule, resource_type, lpEnumFunc, lParam)
+    _BaseEnumResourceNames(hModule, resource_type, lpEnumFunc, lParam)
 
 
 def _EnumResourceLanguages(hModule, lpType, lpName, lpEnumFunc, lParam):
     resource_type = LPCWSTR(lpType)
     resource_name = LPCWSTR(lpName)
-    return _BaseEnumResourceLanguages(
+    _BaseEnumResourceLanguages(
         hModule, resource_type, resource_name, lpEnumFunc, lParam)
 
 

--- a/win32ctypes/core/ctypes/_kernel32.py
+++ b/win32ctypes/core/ctypes/_kernel32.py
@@ -75,13 +75,13 @@ _FreeLibrary = function_factory(
     kernel32.FreeLibrary,
     [HMODULE],
     BOOL,
-    check_zero)
+    check_false)
 
 _EnumResourceTypes = function_factory(
     kernel32.EnumResourceTypesW,
     [HMODULE, _ENUMRESTYPEPROC, LONG_PTR],
     BOOL,
-    check_zero)
+    check_false)
 
 _LoadResource = function_factory(
     kernel32.LoadResource,
@@ -111,7 +111,7 @@ _BaseEnumResourceLanguages = function_factory(
     kernel32.EnumResourceLanguagesW,
     [HMODULE, LPCWSTR, LPCWSTR, _ENUMRESLANGPROC, LONG_PTR],
     BOOL,
-    check_zero)
+    check_false)
 
 _BaseFindResourceEx = function_factory(
     kernel32.FindResourceExW,

--- a/win32ctypes/core/ctypes/_kernel32.py
+++ b/win32ctypes/core/ctypes/_kernel32.py
@@ -87,7 +87,7 @@ _LoadResource = function_factory(
     kernel32.LoadResource,
     [HMODULE, HRSRC],
     HGLOBAL,
-    check_zero)
+    check_null)
 
 _LockResource = function_factory(
     kernel32.LockResource,

--- a/win32ctypes/core/ctypes/_kernel32.py
+++ b/win32ctypes/core/ctypes/_kernel32.py
@@ -64,7 +64,9 @@ def ENUMRESLANGPROC(callback):
 
     return _ENUMRESLANGPROC(wrapped)
 
+
 _GetACP = function_factory(kernel32.GetACP, None, UINT)
+
 
 _LoadLibraryEx = function_factory(
     kernel32.LoadLibraryExW,

--- a/win32ctypes/core/ctypes/_kernel32.py
+++ b/win32ctypes/core/ctypes/_kernel32.py
@@ -13,7 +13,7 @@ from ctypes.wintypes import (
     HGLOBAL, LPVOID, UINT, LPWSTR, MAX_PATH)
 
 from ._common import LONG_PTR, IS_INTRESOURCE
-from ._util import check_null, check_zero, function_factory
+from ._util import check_null, check_zero, check_false, function_factory
 
 _ENUMRESTYPEPROC = ctypes.WINFUNCTYPE(BOOL, HMODULE, LPVOID, LONG_PTR)
 _ENUMRESNAMEPROC = ctypes.WINFUNCTYPE(BOOL, HMODULE, LPVOID, LPVOID, LONG_PTR)
@@ -134,13 +134,13 @@ _EndUpdateResource = function_factory(
     kernel32.EndUpdateResourceW,
     [HANDLE, BOOL],
     BOOL,
-    check_zero)
+    check_false)
 
 _BaseUpdateResource = function_factory(
     kernel32.UpdateResourceW,
     [HANDLE, LPCWSTR, LPCWSTR, WORD, LPVOID, DWORD],
     BOOL,
-    check_zero)
+    check_false)
 
 _BaseGetWindowsDirectory = function_factory(
     kernel32.GetWindowsDirectoryW,

--- a/win32ctypes/core/ctypes/_kernel32.py
+++ b/win32ctypes/core/ctypes/_kernel32.py
@@ -170,7 +170,8 @@ def _GetSystemDirectory():
 def _UpdateResource(hUpdate, lpType, lpName, wLanguage, lpData, cbData):
     lp_type = LPCWSTR(lpType)
     lp_name = LPCWSTR(lpName)
-    return _BaseUpdateResource(hUpdate, lp_type, lp_name, wLanguage, lpData, cbData)
+    return _BaseUpdateResource(
+        hUpdate, lp_type, lp_name, wLanguage, lpData, cbData)
 
 
 def _EnumResourceNames(hModule, lpszType, lpEnumFunc, lParam):

--- a/win32ctypes/core/ctypes/_kernel32.py
+++ b/win32ctypes/core/ctypes/_kernel32.py
@@ -169,11 +169,11 @@ def _GetSystemDirectory():
     return ctypes.cast(buffer, LPCWSTR).value
 
 
-def _UpdateResource(hUpdate, lpType, lpName, wLanguage, lpData, cbData):
+def _UpdateResource(hUpdate, lpType, lpName, wLanguage, cData):
     lp_type = LPCWSTR(lpType)
     lp_name = LPCWSTR(lpName)
     _BaseUpdateResource(
-        hUpdate, lp_type, lp_name, wLanguage, lpData, cbData)
+        hUpdate, lp_type, lp_name, wLanguage, cData, len(cData))
 
 
 def _EnumResourceNames(hModule, lpszType, lpEnumFunc, lParam):

--- a/win32ctypes/core/ctypes/_kernel32.py
+++ b/win32ctypes/core/ctypes/_kernel32.py
@@ -169,11 +169,10 @@ def _GetSystemDirectory():
     return ctypes.cast(buffer, LPCWSTR).value
 
 
-def _UpdateResource(hUpdate, lpType, lpName, wLanguage, cData):
+def _UpdateResource(hUpdate, lpType, lpName, wLanguage, lpData, cbData):
     lp_type = LPCWSTR(lpType)
     lp_name = LPCWSTR(lpName)
-    _BaseUpdateResource(
-        hUpdate, lp_type, lp_name, wLanguage, cData, len(cData))
+    _BaseUpdateResource(hUpdate, lp_type, lp_name, wLanguage, lpData, cbData)
 
 
 def _EnumResourceNames(hModule, lpszType, lpEnumFunc, lParam):

--- a/win32ctypes/core/ctypes/_util.py
+++ b/win32ctypes/core/ctypes/_util.py
@@ -60,7 +60,7 @@ check_zero = check_zero_factory()
 
 def check_false_factory(function_name=None):
     def check_false(result, function, arguments, *args):
-        if result == True:
+        if not bool(result):
             error = make_error(function, function_name)
             # In some cases (e.g. running under wine)
             # there is no error we still get a non true

--- a/win32ctypes/core/ctypes/_util.py
+++ b/win32ctypes/core/ctypes/_util.py
@@ -60,7 +60,7 @@ check_zero = check_zero_factory()
 
 def check_false_factory(function_name=None):
     def check_false(result, function, arguments, *args):
-        if not bool(result):
+        if result == True:
             error = make_error(function, function_name)
             # In some cases (e.g. running under wine)
             # there is no error we still get a non true
@@ -68,6 +68,8 @@ def check_false_factory(function_name=None):
             if error.winerror == 0:
                 # False alarm
                 return True
+            else:
+                raise error
         else:
             return True
     return check_false

--- a/win32ctypes/core/ctypes/_util.py
+++ b/win32ctypes/core/ctypes/_util.py
@@ -43,6 +43,7 @@ def check_null_factory(function_name=None):
         return result
     return check_null
 
+
 check_null = check_null_factory()
 
 
@@ -53,7 +54,9 @@ def check_zero_factory(function_name=None):
         return result
     return check_zero
 
+
 check_zero = check_zero_factory()
+
 
 def check_false_factory(function_name=None):
     def check_false(result, function, arguments, *args):
@@ -62,5 +65,6 @@ def check_false_factory(function_name=None):
         else:
             return True
     return check_false
+
 
 check_false = check_false_factory()

--- a/win32ctypes/core/ctypes/_util.py
+++ b/win32ctypes/core/ctypes/_util.py
@@ -61,15 +61,7 @@ check_zero = check_zero_factory()
 def check_false_factory(function_name=None):
     def check_false(result, function, arguments, *args):
         if not bool(result):
-            error = make_error(function, function_name)
-            # In some cases (e.g. running under wine)
-            # there is no error we still get a non true
-            # result.
-            if error.winerror == 0:
-                # False alarm
-                return True
-            else:
-                raise error
+            raise make_error(function, function_name)
         else:
             return True
     return check_false

--- a/win32ctypes/core/ctypes/_util.py
+++ b/win32ctypes/core/ctypes/_util.py
@@ -57,8 +57,7 @@ check_zero = check_zero_factory()
 
 def check_false_factory(function_name=None):
     def check_false(result, function, arguments, *args):
-        # This is intentional
-        if not result == True:
+        if not bool(result):
             raise make_error(function, function_name)
         else:
             return True

--- a/win32ctypes/core/ctypes/_util.py
+++ b/win32ctypes/core/ctypes/_util.py
@@ -54,3 +54,14 @@ def check_zero_factory(function_name=None):
     return check_zero
 
 check_zero = check_zero_factory()
+
+def check_false_factory(function_name=None):
+    def check_false(result, function, arguments, *args):
+        # This is intentional
+        if not result == True:
+            raise make_error(function, function_name)
+        else:
+            return True
+    return check_false
+
+check_false = check_false_factory()

--- a/win32ctypes/core/ctypes/_util.py
+++ b/win32ctypes/core/ctypes/_util.py
@@ -61,7 +61,13 @@ check_zero = check_zero_factory()
 def check_false_factory(function_name=None):
     def check_false(result, function, arguments, *args):
         if not bool(result):
-            raise make_error(function, function_name)
+            error = make_error(function, function_name)
+            # In some cases (e.g. running under wine)
+            # there is no error we still get a non true
+            # result.
+            if error.winerror == 0:
+                # False alarm
+                return True
         else:
             return True
     return check_false

--- a/win32ctypes/pywin32/win32api.py
+++ b/win32ctypes/pywin32/win32api.py
@@ -281,6 +281,8 @@ def UpdateResource(handle, type, name, data, language=LANG_NEUTRAL):
         The type of resource to update.
     name : str : int
         The name or Id of the resource to update.
+    data : bytes
+        A bytes like object is expected.
     language : int
         Language to use, default is LANG_NEUTRAL.
 
@@ -289,9 +291,9 @@ def UpdateResource(handle, type, name, data, language=LANG_NEUTRAL):
     - `UpdateResource MSDN reference <https://msdn.microsoft.com/en-us/library/windows/desktop/ms648049(v=vs.85).aspx>`_
 
     """
+
     with _pywin32error():
-        _kernel32._UpdateResource(
-            handle, type, name, language, data, len(data))
+        _kernel32._UpdateResource(handle, type, name, language, bytes(data))
 
 
 def GetWindowsDirectory():

--- a/win32ctypes/pywin32/win32api.py
+++ b/win32ctypes/pywin32/win32api.py
@@ -212,21 +212,20 @@ def GetTickCount():
     return _kernel32._GetTickCount()
 
 
-def BeginUpdateResource(pFileName, bDeleteExistingResources):
+def BeginUpdateResource(filename, delete):
     with _pywin32error():
-        return _kernel32._BeginUpdateResource(
-            pFileName, bDeleteExistingResources)
+        return _kernel32._BeginUpdateResource(filename, delete)
 
 
-def EndUpdateResource(hUpdate, fDiscard):
+def EndUpdateResource(handle, discard):
     with _pywin32error():
-        return _kernel32._EndUpdateResource(hUpdate, fDiscard)
+        return _kernel32._EndUpdateResource(handle, discard)
 
 
-def UpdateResource(hUpdate, lpType, lpName, lpData, wLanguage):
+def UpdateResource(handle, type, name, data, language=LANG_NEUTRAL):
     with _pywin32error():
         return _kernel32._UpdateResource(
-            hUpdate, lpType, lpName, wLanguage, lpData, len(lpData))
+            handle, type, name, language, data, len(data))
 
 
 def GetWindowsDirectory():

--- a/win32ctypes/pywin32/win32api.py
+++ b/win32ctypes/pywin32/win32api.py
@@ -161,7 +161,7 @@ def LoadResource(hModule, type, name, language=LANG_NEUTRAL):
         Use None for current process executable.
     type : str : int
         The type of resource to load.
-    name :
+    name : str : int
         The name or Id of the resource to load.
     language : int
         Language to use, default is LANG_NEUTRAL.
@@ -169,7 +169,7 @@ def LoadResource(hModule, type, name, language=LANG_NEUTRAL):
     Returns
     -------
     hModule :
-        Handle of the loaded source.
+        Handle of the loaded resource.
 
     See also
     --------
@@ -209,32 +209,122 @@ def FreeLibrary(hModule):
 
 
 def GetTickCount():
+    """ The number of milliseconds that have elapsed since startup
+
+    Returns
+    -------
+    int:
+        The millisecond counts since system startup. Can count up
+        to 49.7 days.
+
+    See also
+    --------
+    - `GetTickCount MSDN reference <https://msdn.microsoft.com/en-us/library/windows/desktop/ms724408%28v=vs.85%29.aspx>`_
+
+    """
     return _kernel32._GetTickCount()
 
 
 def BeginUpdateResource(filename, delete):
+    """ Get a handle that can be used by the :func:`UpdateResource`.
+
+    Parameters
+    ----------
+    fileName : unicode
+        The filename of the module to load.
+    delete : bool
+        When true all existing resources are deleted
+
+    Returns
+    -------
+    hModule :
+        Handle of the resource.
+
+    See also
+    --------
+    - `BeginUpdateResource MSDN reference <https://msdn.microsoft.com/en-us/library/windows/desktop/ms648030(v=vs.85).aspx>`_
+
+    """
     with _pywin32error():
         return _kernel32._BeginUpdateResource(filename, delete)
 
 
 def EndUpdateResource(handle, discard):
+    """ End the update resource of the handle.
+
+    Parameters
+    ----------
+    handle : hModule
+        The handle of the resource as it is returned
+        by :func:`BeginUpdateResource`
+    discard : bool
+        When True all writes are discarded.
+
+    See also
+    --------
+    - `EndUpdateResource MSDN reference <https://msdn.microsoft.com/en-us/library/windows/desktop/ms648032(v=vs.85).aspx>`_
+
+    """
     with _pywin32error():
         return _kernel32._EndUpdateResource(handle, discard)
 
 
 def UpdateResource(handle, type, name, data, language=LANG_NEUTRAL):
+    """ Update a resource.
+
+    Parameters
+    ----------
+    handle :
+        The handle of the resource file as returned by
+        :func:`BeginUpdateResource`.
+    type : str : int
+        The type of resource to update.
+    name : str : int
+        The name or Id of the resource to update.
+    language : int
+        Language to use, default is LANG_NEUTRAL.
+
+    See also
+    --------
+    - `UpdateResource MSDN reference <https://msdn.microsoft.com/en-us/library/windows/desktop/ms648049(v=vs.85).aspx>`_
+
+    """
     with _pywin32error():
         return _kernel32._UpdateResource(
             handle, type, name, language, data, len(data))
 
 
 def GetWindowsDirectory():
+    """ Get the ``Windows`` directory.
+
+    Returns
+    -------
+    str :
+        The path to the ``Windows`` directory.
+
+    See also
+    --------
+    - `GetWindowsDirectory MSDN reference <https://msdn.microsoft.com/en-us/library/windows/desktop/ms648049(v=vs.85).aspx>`_
+
+    """
     with _pywin32error():
         # Note: pywin32 returns str on py27, unicode (which is str) on py3
         return str(_kernel32._GetWindowsDirectory())
 
 
 def GetSystemDirectory():
+    """ Get the ``System`` directory.
+
+    Returns
+    -------
+    str :
+        The path to the ``System`` directory.
+
+    See also
+    --------
+    - `GetSystemDirectory MSDN reference <https://msdn.microsoft.com/en-us/library/windows/desktop/ms724373(v=vs.85).aspx>`_
+
+    """
     with _pywin32error():
         # Note: pywin32 returns str on py27, unicode (which is str) on py3
         return str(_kernel32._GetSystemDirectory())

--- a/win32ctypes/pywin32/win32api.py
+++ b/win32ctypes/pywin32/win32api.py
@@ -266,7 +266,7 @@ def EndUpdateResource(handle, discard):
 
     """
     with _pywin32error():
-        return _kernel32._EndUpdateResource(handle, discard)
+        _kernel32._EndUpdateResource(handle, discard)
 
 
 def UpdateResource(handle, type, name, data, language=LANG_NEUTRAL):
@@ -290,7 +290,7 @@ def UpdateResource(handle, type, name, data, language=LANG_NEUTRAL):
 
     """
     with _pywin32error():
-        return _kernel32._UpdateResource(
+        _kernel32._UpdateResource(
             handle, type, name, language, data, len(data))
 
 

--- a/win32ctypes/pywin32/win32api.py
+++ b/win32ctypes/pywin32/win32api.py
@@ -293,7 +293,18 @@ def UpdateResource(handle, type, name, data, language=LANG_NEUTRAL):
     """
 
     with _pywin32error():
-        _kernel32._UpdateResource(handle, type, name, language, bytes(data))
+        try:
+            lp_data = bytes(data)
+        except UnicodeEncodeError:
+            # FIXME: In python 2.7 pipywin32219 can handle unicode.
+            #        However the data are stored as bytes and it
+            #        is not really possible to convert the information
+            #        back into the original unicode string. This looks
+            #        like a bug so we follow the python 3 behavior.
+            raise TypeError(
+                "a bytes-like object is required, not a 'unicode'")
+        _kernel32._UpdateResource(
+            handle, type, name, language, lp_data, len(lp_data))
 
 
 def GetWindowsDirectory():

--- a/win32ctypes/tests/compat.py
+++ b/win32ctypes/tests/compat.py
@@ -68,8 +68,7 @@ if sys.version_info[:2] == (2, 6):
             if result is not None:
                 errors = result.errors
                 skip_error = (
-                    'in skipTest\n    raise SkipException(msg)'
-                    '\nSkipException:')
+                    'in skipTest\n    raise SkipException(msg)')
                 result.errors = []
                 for error in errors:
                     if skip_error in error[1]:

--- a/win32ctypes/tests/test_win32api.py
+++ b/win32ctypes/tests/test_win32api.py
@@ -186,7 +186,7 @@ class TestWin32API(compat.TestCase):
 
     def test_get_system_directory(self):
         # given
-        r = self.module.GetSystemDirectory()
+        expected = win32api.GetSystemDirectory()
 
         # when
         result = self.module.GetSystemDirectory()

--- a/win32ctypes/tests/test_win32api.py
+++ b/win32ctypes/tests/test_win32api.py
@@ -182,7 +182,7 @@ class TestWin32API(compat.TestCase):
         # then
         self.assertTrue(isinstance(result, str))
         self.assertEqual(result.lower(), r"c:\windows")
-        self.assertEqual(result.lower(), expected)
+        self.assertEqual(result, expected)
 
     def test_get_system_directory(self):
         # given
@@ -194,7 +194,7 @@ class TestWin32API(compat.TestCase):
         # then
         self.assertTrue(isinstance(result, str))
         self.assertEqual(result.lower(), r"c:\windows\system32")
-        self.assertEqual(result.lower(), expected)
+        self.assertEqual(result, expected)
 
 
 if __name__ == '__main__':

--- a/win32ctypes/tests/test_win32api.py
+++ b/win32ctypes/tests/test_win32api.py
@@ -186,7 +186,7 @@ class TestWin32API(compat.TestCase):
 
     def test_begin_update_resource_with_invalid(self):
         # when/then
-        with self.assertRaises(error):
+        with self.assertRaises(error) as context:
             self.module.BeginUpdateResource('invalid', False)
         # the errno cannot be 0 (i.e. success)
         self.assertNotEqual(context.exception.winerror, 0)

--- a/win32ctypes/tests/test_win32api.py
+++ b/win32ctypes/tests/test_win32api.py
@@ -188,14 +188,13 @@ class TestWin32API(compat.TestCase):
         # when/then
         with self.assertRaises(error):
             self.module.BeginUpdateResource('invalid', False)
+        self.assertNotEqual(error.winerror, 0)
 
     def test_end_update_resource_with_invalid(self):
-        if skip_on_wine:
-            self.skipTest('EndUpdateResource known failure on wine, see #59')
-
         # when/then
         with self.assertRaises(error):
             self.module.EndUpdateResource(-3, False)
+        self.assertNotEqual(error.winerror, 0)
 
     def test_update_resource(self):
         # given

--- a/win32ctypes/tests/test_win32api.py
+++ b/win32ctypes/tests/test_win32api.py
@@ -202,6 +202,23 @@ class TestWin32API(compat.TestCase):
         self.assertEqual(len(updated), len(resource) - 2)
         self.assertEqual(updated, resource[:-2])
 
+        # when
+        handle = module.BeginUpdateResource(filename, False)
+        resource = u"\N{GREEK CAPITAL LETTER DELTA}"
+        try:
+                module.UpdateResource(
+                    handle, resource_type, resource_name,
+                    resource,
+                    resource_language)
+        finally:
+            module.EndUpdateResource(handle, False)
+
+        # then
+        with self.load_library(self.module, filename) as handle:
+            updated = module.LoadResource(
+                handle, resource_type, resource_name, resource_language)
+        self.assertEqual(updated, resource.encode('utf8'))
+
     def test_get_windows_directory(self):
         # given
         expected = win32api.GetWindowsDirectory()

--- a/win32ctypes/tests/test_win32api.py
+++ b/win32ctypes/tests/test_win32api.py
@@ -203,21 +203,17 @@ class TestWin32API(compat.TestCase):
         self.assertEqual(updated, resource[:-2])
 
         # when
-        handle = module.BeginUpdateResource(filename, False)
         resource = u"\N{GREEK CAPITAL LETTER DELTA}"
+        handle = module.BeginUpdateResource(filename, False)
         try:
+            # then only byte like objects are expected.
+            with self.assertRaises(TypeError):
                 module.UpdateResource(
                     handle, resource_type, resource_name,
                     resource,
                     resource_language)
         finally:
             module.EndUpdateResource(handle, False)
-
-        # then
-        with self.load_library(self.module, filename) as handle:
-            updated = module.LoadResource(
-                handle, resource_type, resource_name, resource_language)
-        self.assertEqual(updated, resource.encode('utf8'))
 
     def test_get_windows_directory(self):
         # given

--- a/win32ctypes/tests/test_win32api.py
+++ b/win32ctypes/tests/test_win32api.py
@@ -166,12 +166,6 @@ class TestWin32API(compat.TestCase):
         self.assertEqual(len(updated), len(resource) - 2)
         self.assertEqual(updated, resource[:-2])
 
-    def _id2str(self, type_id):
-        if hasattr(type_id, 'index'):
-            return type_id
-        else:
-            return u'#{0}'.format(type_id)
-
     def test_get_windows_directory(self):
         # given
         expected = win32api.GetWindowsDirectory()
@@ -180,7 +174,7 @@ class TestWin32API(compat.TestCase):
         result = self.module.GetWindowsDirectory()
 
         # then
-        self.assertTrue(isinstance(result, str))
+        self.assertIsInstance(result, str)
         self.assertEqual(result.lower(), r"c:\windows")
         self.assertEqual(result, expected)
 
@@ -192,9 +186,15 @@ class TestWin32API(compat.TestCase):
         result = self.module.GetSystemDirectory()
 
         # then
-        self.assertTrue(isinstance(result, str))
+        self.assertIsInstance(result, str)
         self.assertEqual(result.lower(), r"c:\windows\system32")
         self.assertEqual(result, expected)
+
+    def _id2str(self, type_id):
+        if hasattr(type_id, 'index'):
+            return type_id
+        else:
+            return u'#{0}'.format(type_id)
 
 
 if __name__ == '__main__':

--- a/win32ctypes/tests/test_win32api.py
+++ b/win32ctypes/tests/test_win32api.py
@@ -94,7 +94,7 @@ class TestWin32API(compat.TestCase):
         with self.assertRaises(error):
             self.module.EnumResourceNames(2, 3)
 
-    def test_enum_resource_languages(self):
+    def _test_enum_resource_languages(self):
         with self.load_library(win32api, u'shell32.dll') as handle:
             resource_types = win32api.EnumResourceTypes(handle)
             for resource_type in resource_types:
@@ -185,7 +185,10 @@ class TestWin32API(compat.TestCase):
             self.assertEqual(len(module.EnumResourceTypes(handle)), 0)
 
     def test_begin_update_resource_with_invalid(self):
-        # when/then
+        if skip_on_wine:
+            self.skipTest('BeginUpdateResource known failure on wine, see #59')
+
+            # when/then
         with self.assertRaises(error) as context:
             self.module.BeginUpdateResource('invalid', False)
         # the errno cannot be 0 (i.e. success)
@@ -193,7 +196,7 @@ class TestWin32API(compat.TestCase):
 
     def test_end_update_resource_with_invalid(self):
         if skip_on_wine:
-            self.skipTest('EnumResourceTypes known failure on wine, see #59')
+            self.skipTest('EndUpdateResource known failure on wine, see #59')
 
         # when/then
         with self.assertRaises(error) as context:

--- a/win32ctypes/tests/test_win32api.py
+++ b/win32ctypes/tests/test_win32api.py
@@ -134,7 +134,6 @@ class TestWin32API(compat.TestCase):
     def test_get_tick_count(self):
         self.assertGreater(self.module.GetTickCount(), 0.0)
 
-
     def test_begin_and_end_update_resource(self):
         # given
         module = self.module
@@ -190,8 +189,8 @@ class TestWin32API(compat.TestCase):
         handle = module.BeginUpdateResource(filename, False)
         try:
             module.UpdateResource(
-                    handle, resource_type, resource_name, resource[:-2],
-                    resource_language)
+                handle, resource_type, resource_name, resource[:-2],
+                resource_language)
         finally:
             module.EndUpdateResource(handle, False)
 

--- a/win32ctypes/tests/test_win32api.py
+++ b/win32ctypes/tests/test_win32api.py
@@ -208,7 +208,7 @@ class TestWin32API(compat.TestCase):
 
     def test_update_resource_with_unicode(self):
         # given
-        module = win32api
+        module = self.module
         filename = os.path.join(self.tempdir, 'python.exe')
         with self.load_library(module, filename) as handle:
             resource_type = module.EnumResourceTypes(handle)[-1]

--- a/win32ctypes/tests/test_win32api.py
+++ b/win32ctypes/tests/test_win32api.py
@@ -22,14 +22,14 @@ from win32ctypes.tests import compat
 
 class TestWin32API(compat.TestCase):
 
+    module = pywin32.win32api
+
     def setUp(self):
         self.tempdir = tempfile.mkdtemp()
         shutil.copy(sys.executable, self.tempdir)
 
     def tearDown(self):
         shutil.rmtree(self.tempdir)
-
-    module = pywin32.win32api
 
     @contextlib.contextmanager
     def load_library(self, module, library=sys.executable, flags=0x2):

--- a/win32ctypes/tests/test_win32api.py
+++ b/win32ctypes/tests/test_win32api.py
@@ -191,6 +191,9 @@ class TestWin32API(compat.TestCase):
         self.assertNotEqual(error.winerror, 0)
 
     def test_end_update_resource_with_invalid(self):
+        if skip_on_wine:
+            self.skipTest('EnumResourceTypes known failure on wine, see #59')
+
         # when/then
         with self.assertRaises(error):
             self.module.EndUpdateResource(-3, False)

--- a/win32ctypes/tests/test_win32api.py
+++ b/win32ctypes/tests/test_win32api.py
@@ -166,6 +166,14 @@ class TestWin32API(compat.TestCase):
         with self.load_library(self.module, filename) as handle:
             self.assertEqual(len(module.EnumResourceTypes(handle)), 0)
 
+        # when/then
+        with self.assertRaises(error):
+            handle = module.BeginUpdateResource('invalid', False)
+
+        # when/then
+        with self.assertRaises(error):
+            handle = module.EndUpdateResource(-3, False)
+
     def test_update_resource(self):
         # given
         module = self.module

--- a/win32ctypes/tests/test_win32api.py
+++ b/win32ctypes/tests/test_win32api.py
@@ -144,7 +144,7 @@ class TestWin32API(compat.TestCase):
 
         # when
         handle = module.BeginUpdateResource(filename, False)
-        self.assertTrue(module.EndUpdateResource(handle, False))
+        module.EndUpdateResource(handle, False)
 
         # then
         with self.load_library(self.module, filename) as handle:
@@ -152,7 +152,7 @@ class TestWin32API(compat.TestCase):
 
         # when
         handle = module.BeginUpdateResource(filename, True)
-        self.assertTrue(module.EndUpdateResource(handle, True))
+        module.EndUpdateResource(handle, True)
 
         # then
         with self.load_library(self.module, filename) as handle:
@@ -160,7 +160,7 @@ class TestWin32API(compat.TestCase):
 
         # when
         handle = module.BeginUpdateResource(filename, True)
-        self.assertTrue(module.EndUpdateResource(handle, False))
+        module.EndUpdateResource(handle, False)
 
         # then
         with self.load_library(self.module, filename) as handle:
@@ -181,12 +181,11 @@ class TestWin32API(compat.TestCase):
         # when
         handle = module.BeginUpdateResource(filename, False)
         try:
-            self.assertTrue(
-                module.UpdateResource(
+            module.UpdateResource(
                     handle, resource_type, resource_name, resource[:-2],
-                    resource_language))
+                    resource_language)
         finally:
-            self.assertTrue(module.EndUpdateResource(handle, False))
+            module.EndUpdateResource(handle, False)
 
         # then
         with self.load_library(self.module, filename) as handle:

--- a/win32ctypes/tests/test_win32api.py
+++ b/win32ctypes/tests/test_win32api.py
@@ -136,9 +136,35 @@ class TestWin32API(compat.TestCase):
 
 
     def test_begin_and_end_update_resource(self):
+        # given
+        module = self.module
         filename = os.path.join(self.tempdir, 'python.exe')
-        handle = self.module.BeginUpdateResource(filename, False)
-        self.assertTrue(self.module.EndUpdateResource(handle, False))
+        with self.load_library(self.module, filename) as handle:
+            count = len(module.EnumResourceTypes(handle))
+
+        # when
+        handle = module.BeginUpdateResource(filename, False)
+        self.assertTrue(module.EndUpdateResource(handle, False))
+
+        # then
+        with self.load_library(self.module, filename) as handle:
+            self.assertEqual(len(module.EnumResourceTypes(handle)), count)
+
+        # when
+        handle = module.BeginUpdateResource(filename, True)
+        self.assertTrue(module.EndUpdateResource(handle, True))
+
+        # then
+        with self.load_library(self.module, filename) as handle:
+            self.assertEqual(len(module.EnumResourceTypes(handle)), count)
+
+        # when
+        handle = module.BeginUpdateResource(filename, True)
+        self.assertTrue(module.EndUpdateResource(handle, False))
+
+        # then
+        with self.load_library(self.module, filename) as handle:
+            self.assertEqual(len(module.EnumResourceTypes(handle)), 0)
 
     def test_update_resource(self):
         # given

--- a/win32ctypes/tests/test_win32api.py
+++ b/win32ctypes/tests/test_win32api.py
@@ -188,16 +188,18 @@ class TestWin32API(compat.TestCase):
         # when/then
         with self.assertRaises(error):
             self.module.BeginUpdateResource('invalid', False)
-        self.assertNotEqual(error.winerror, 0)
+        # the errno cannot be 0 (i.e. success)
+        self.assertNotEqual(context.exception.winerror, 0)
 
     def test_end_update_resource_with_invalid(self):
         if skip_on_wine:
             self.skipTest('EnumResourceTypes known failure on wine, see #59')
 
         # when/then
-        with self.assertRaises(error):
+        with self.assertRaises(error) as context:
             self.module.EndUpdateResource(-3, False)
-        self.assertNotEqual(error.winerror, 0)
+        # the errno cannot be 0 (i.e. success)
+        self.assertNotEqual(context.exception.winerror, 0)
 
     def test_update_resource(self):
         # given

--- a/win32ctypes/tests/test_win32api.py
+++ b/win32ctypes/tests/test_win32api.py
@@ -25,7 +25,9 @@ class TestWin32API(compat.TestCase):
     def setUp(self):
         self.tempdir = tempfile.mkdtemp()
         shutil.copy(sys.executable, self.tempdir)
-        self.addCleanup(shutil.rmtree, self.tempdir)
+
+    def tearDown(self):
+        shutil.rmtree(self.tempdir)
 
     module = pywin32.win32api
 

--- a/win32ctypes/tests/test_win32api.py
+++ b/win32ctypes/tests/test_win32api.py
@@ -172,17 +172,29 @@ class TestWin32API(compat.TestCase):
         else:
             return u'#{0}'.format(type_id)
 
-    # note: pywin32 returns str on py27, unicode (which is str) on py3
-
     def test_get_windows_directory(self):
-        r = self.module.GetWindowsDirectory()
-        self.assertTrue(isinstance(r, str))
-        self.assertEqual(r.lower(), r"c:\windows")
-        
+        # given
+        expected = win32api.GetWindowsDirectory()
+
+        # when
+        result = self.module.GetWindowsDirectory()
+
+        # then
+        self.assertTrue(isinstance(result, str))
+        self.assertEqual(result.lower(), r"c:\windows")
+        self.assertEqual(result.lower(), expected)
+
     def test_get_system_directory(self):
+        # given
         r = self.module.GetSystemDirectory()
-        self.assertTrue(isinstance(r, str))
-        self.assertEqual(r.lower(), r"c:\windows\system32")
+
+        # when
+        result = self.module.GetSystemDirectory()
+
+        # then
+        self.assertTrue(isinstance(result, str))
+        self.assertEqual(result.lower(), r"c:\windows\system32")
+        self.assertEqual(result.lower(), expected)
 
 
 if __name__ == '__main__':

--- a/win32ctypes/tests/test_win32api.py
+++ b/win32ctypes/tests/test_win32api.py
@@ -136,7 +136,7 @@ class TestWin32API(compat.TestCase):
     def test_begin_and_end_update_resource(self):
         filename = os.path.join(self.tempdir, 'python.exe')
         handle = self.module.BeginUpdateResource(filename, False)
-        self.module.EndUpdateResource(handle, False)
+        self.assertTrue(self.module.EndUpdateResource(handle, False))
 
     def test_update_resource(self):
         # given
@@ -153,11 +153,12 @@ class TestWin32API(compat.TestCase):
         # when
         handle = module.BeginUpdateResource(filename, False)
         try:
-            module.UpdateResource(
-                handle, resource_type, resource_name, resource[:-2],
-                resource_language)
+            self.assertTrue(
+                module.UpdateResource(
+                    handle, resource_type, resource_name, resource[:-2],
+                    resource_language))
         finally:
-            module.EndUpdateResource(handle, False)
+            self.assertTrue(module.EndUpdateResource(handle, False))
 
         # then
         with self.load_library(self.module, filename) as handle:


### PR DESCRIPTION
Changes:
- Cherry-picked commits from #53 
- Minor cleanup in the tests
- Augment tests for BeginUpdateResource and EndUpdateResource.
- Add `check_false` factories to check specifically for boolean result.
- Add workaround in `check_false` for issues with `EnumResourseTypesW` in wine.
- Add the function name in the cffi wrappings of kernel32 function to properly populate the `error` info.
- Fix UpdateResource to behave like pywin32
- [x] Fix `wine` errors
