### PR TITLE
Add support for CredEnumerate

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ version = open(
 
 filename = os.path.join(HERE, 'win32ctypes', 'version.py')
 with open(filename, 'w') as handle:
-    handle.write('__version__="%s"\n' % version)
+    handle.write(f'__version__ = "{version}"\n')
 
 setup(
     name='pywin32-ctypes',

--- a/win32ctypes/core/cffi/_common.py
+++ b/win32ctypes/core/cffi/_common.py
@@ -8,7 +8,6 @@
 from weakref import WeakKeyDictionary
 
 from ._util import ffi
-from .ffi import cast, new  # noqa imported here for convenience
 
 _keep_alive = WeakKeyDictionary()
 
@@ -19,7 +18,7 @@ def _PyBytes_FromStringAndSize(pointer, size):
 
 
 def byreference(x):
-    return new(ffi.getctype(ffi.typeof(x), '*'), x)
+    return ffi.new(ffi.getctype(ffi.typeof(x), '*'), x)
 
 
 def dereference(x):
@@ -27,4 +26,4 @@ def dereference(x):
 
 
 def PDWORD(value=0):
-    return new("DWORD *", value)
+    return ffi.new("DWORD *", value)

--- a/win32ctypes/core/cffi/_common.py
+++ b/win32ctypes/core/cffi/_common.py
@@ -8,6 +8,7 @@
 from weakref import WeakKeyDictionary
 
 from ._util import ffi
+from .ffi import cast, new  # noqa imported here for convenience
 
 _keep_alive = WeakKeyDictionary()
 
@@ -18,8 +19,12 @@ def _PyBytes_FromStringAndSize(pointer, size):
 
 
 def byreference(x):
-    return ffi.new(ffi.getctype(ffi.typeof(x), '*'), x)
+    return new(ffi.getctype(ffi.typeof(x), '*'), x)
 
 
 def dereference(x):
     return x[0]
+
+
+def PDWORD(value=0):
+    return new("DWORD *", value)

--- a/win32ctypes/core/ctypes/_authentication.py
+++ b/win32ctypes/core/ctypes/_authentication.py
@@ -96,8 +96,8 @@ def credential2dict(creds):
 
 
 def _CredEnumerate(Filter, Flags, Count, pppCredential):
-    filter = LPCWSTR(Filter)
-    _BaseCredEnumerate(Filter, Flags, Count, pppCredential)
+    filter_ = LPCWSTR(Filter)
+    _BaseCredEnumerate(filter_, Flags, Count, pppCredential)
 
 
 _CredWrite = function_factory(

--- a/win32ctypes/core/ctypes/_common.py
+++ b/win32ctypes/core/ctypes/_common.py
@@ -9,7 +9,7 @@ import ctypes
 import sys
 from ctypes import (
     pythonapi, POINTER, c_void_p, py_object, c_char_p, c_int, c_long, c_int64,
-    c_longlong)
+    c_longlong, c_ubyte)
 from ctypes import cast  # noqa imported here for convenience
 from ctypes.wintypes import BYTE, DWORD
 
@@ -17,7 +17,6 @@ from ._util import function_factory
 
 PPy_UNICODE = c_void_p
 LPBYTE = POINTER(BYTE)
-PDWORD = POINTER(DWORD)
 is_64bits = sys.maxsize > 2**32
 Py_ssize_t = c_int64 if is_64bits else c_int
 

--- a/win32ctypes/core/ctypes/_common.py
+++ b/win32ctypes/core/ctypes/_common.py
@@ -11,12 +11,13 @@ from ctypes import (
     pythonapi, POINTER, c_void_p, py_object, c_char_p, c_int, c_long, c_int64,
     c_longlong)
 from ctypes import cast  # noqa imported here for convenience
-from ctypes.wintypes import BYTE
+from ctypes.wintypes import BYTE, DWORD
 
 from ._util import function_factory
 
 PPy_UNICODE = c_void_p
 LPBYTE = POINTER(BYTE)
+PDWORD = POINTER(DWORD)
 is_64bits = sys.maxsize > 2**32
 Py_ssize_t = c_int64 if is_64bits else c_int
 

--- a/win32ctypes/core/ctypes/_common.py
+++ b/win32ctypes/core/ctypes/_common.py
@@ -9,9 +9,9 @@ import ctypes
 import sys
 from ctypes import (
     pythonapi, POINTER, c_void_p, py_object, c_char_p, c_int, c_long, c_int64,
-    c_longlong, c_ubyte)
+    c_longlong)
 from ctypes import cast  # noqa imported here for convenience
-from ctypes.wintypes import BYTE, DWORD
+from ctypes.wintypes import BYTE
 
 from ._util import function_factory
 

--- a/win32ctypes/pywin32/pywintypes.py
+++ b/win32ctypes/pywin32/pywintypes.py
@@ -32,4 +32,6 @@ def pywin32error():
     try:
         yield
     except WindowsError as exception:
+        if not hasattr(exception, 'function'):
+            exception.function = 'unknown'
         raise error(exception.winerror, exception.function, exception.strerror)

--- a/win32ctypes/pywin32/win32cred.py
+++ b/win32ctypes/pywin32/win32cred.py
@@ -114,8 +114,8 @@ def CredEnumerate(Filter=None, Flags=0):
             pppcreds = _authentication.PPPCREDENTIAL()
             _authentication._CredEnumerate(Filter, Flags, pcount, pppcreds)
             count = pcount[0]
-            pppcreds = _common.ffi.cast(f"PCREDENTIAL*[{count}]", pppcreds)
-            ppcreds = _common.dereference(pppcreds)
+            pcreds = _common.dereference(
+                _common.ffi.cast(f"PCREDENTIAL*[{count}]", pppcreds))
         else:
             import ctypes
             count = _common.DWORD()

--- a/win32ctypes/pywin32/win32cred.py
+++ b/win32ctypes/pywin32/win32cred.py
@@ -14,6 +14,7 @@ CRED_PERSIST_SESSION = 0x1
 CRED_PERSIST_LOCAL_MACHINE = 0x2
 CRED_PERSIST_ENTERPRISE = 0x3
 CRED_PRESERVE_CREDENTIAL_BLOB = 0
+CRED_ENUMERATE_ALL_CREDENTIALS = 0x1
 
 
 def CredWrite(Credential, Flags=CRED_PRESERVE_CREDENTIAL_BLOB):
@@ -89,3 +90,43 @@ def CredDelete(TargetName, Type, Flags=0):
         raise ValueError("Type != CRED_TYPE_GENERIC not yet supported.")
     with _pywin32error():
         _authentication._CredDelete(TargetName, Type, 0)
+
+
+def CredEnumerate(Filter=None, Flags=0):
+    """ Remove the given target name from the stored credentials.
+
+    Parameters
+    ----------
+    Filter : unicode
+        Matches credentials' target names by prefix, can be None.
+    Flags : int
+        Reserved, use 0 if passed in.
+
+    Returns
+    -------
+    credentials : list
+        Returns a sequence of CREDENTIAL dictionaries.
+
+    """
+    with _pywin32error():
+        if _backend == 'cffi':
+            pcount = _common.PDWORD()
+            pppcreds = _authentication.PPPCREDENTIAL()
+            _authentication._CredEnumerate(Filter, Flags, pcount, pppcreds)
+            count = pcount[0]
+            pppcreds = _common.cast(f"PCREDENTIAL*[{count}]", pppcreds)
+            ppcreds = _common.dereference(pppcreds)
+        else:
+            pppcreds = _authentication.PPPCREDENTIAL()
+            print(pppcreds)
+            pcount = _common.PDWORD()
+            _authentication._CredEnumerate(Filter, Flags, pcount, pppcreds)
+            print(pcount)
+
+    try:
+        return [
+            _authentication.credential2dict(ppcreds[i])
+            for i in range(count)]
+    finally:
+        for i in range(count):
+            _authentication._CredFree(ppcreds[i])

--- a/win32ctypes/pywin32/win32cred.py
+++ b/win32ctypes/pywin32/win32cred.py
@@ -100,7 +100,10 @@ def CredEnumerate(Filter=None, Flags=0):
     Filter : unicode
         Matches credentials' target names by prefix, can be None.
     Flags : int
-        Reserved, use 0 if passed in.
+        When set to CRED_ENUMERATE_ALL_CREDENTIALS enumerates all of
+        the credentials in the user's credential set but in that
+        case the Filter parameter should be NULL, an error is
+        raised otherwise
 
     Returns
     -------

--- a/win32ctypes/pywin32/win32cred.py
+++ b/win32ctypes/pywin32/win32cred.py
@@ -118,7 +118,7 @@ def CredEnumerate(Filter=None, Flags=0):
                 _common.ffi.cast(f"PCREDENTIAL*[{count}]", pppcreds))
         else:
             import ctypes
-            count = _common.DWORD()
+            count = ctypes.DWORD()
             # Create a mutable pointer variable
             mem = ctypes.create_string_buffer(1)
             pppcreds = _common.cast(

--- a/win32ctypes/pywin32/win32cred.py
+++ b/win32ctypes/pywin32/win32cred.py
@@ -114,7 +114,7 @@ def CredEnumerate(Filter=None, Flags=0):
             pppcreds = _authentication.PPPCREDENTIAL()
             _authentication._CredEnumerate(Filter, Flags, pcount, pppcreds)
             count = pcount[0]
-            pppcreds = _common.cast(f"PCREDENTIAL*[{count}]", pppcreds)
+            pppcreds = _common.ffi.cast(f"PCREDENTIAL*[{count}]", pppcreds)
             ppcreds = _common.dereference(pppcreds)
         else:
             pppcreds = _authentication.PPPCREDENTIAL()

--- a/win32ctypes/tests/test_win32cred.py
+++ b/win32ctypes/tests/test_win32cred.py
@@ -31,8 +31,9 @@ else:
 class TestCred(unittest.TestCase):
 
     def setUp(self):
+        from pywintypes import error
         try:
-            win32cred.CredDelete(u'jone@doe', 0)
+            win32cred.CredDelete(u'jone@doe', CRED_TYPE_GENERIC)
         except error:
             pass
 

--- a/win32ctypes/tests/test_win32cred.py
+++ b/win32ctypes/tests/test_win32cred.py
@@ -134,16 +134,13 @@ class TestCred(unittest.TestCase):
         CredWrite(r_credentials)
 
         # when
+        pywin32_result = win32cred.CredEnumerate()
         credentials = CredEnumerate()
 
         # then
-        self.assertGreater(len(credentials), 1)
+        self.assertEqual(len(credentials), len(pywin32_result))
 
     def test_enumerate_all(self):
-        # given
-        r_credentials = self._demo_credentials()
-        CredWrite(r_credentials)
-
         # when
         credentials = CredEnumerate(Flags=CRED_ENUMERATE_ALL_CREDENTIALS)
 

--- a/win32ctypes/tests/test_win32cred.py
+++ b/win32ctypes/tests/test_win32cred.py
@@ -30,165 +30,144 @@ else:
 
 class TestCred(unittest.TestCase):
 
+    def setUp(self):
+        try:
+            win32cred.CredDelete(u'jone@doe')
+        except error:
+            pass
+
+    def _demo_credentials(self):
+        return {
+            "Type": CRED_TYPE_GENERIC,
+            "TargetName": u'jone@doe',
+            "UserName": u'jone',
+            "CredentialBlob": u"doefsajfsakfj",
+            "Comment": u"Created by MiniPyWin32Cred test suite",
+            "Persist": CRED_PERSIST_ENTERPRISE}
+
     @unittest.skipIf(
         pywin32_build == "223" and sys.version_info[:2] == (3, 7),
         "pywin32 version 223 bug with CredRead (mhammond/pywin32#1232)")
     def test_write_to_pywin32(self):
-        username = u"john"
-        password = u"doefsajfsakfj"
-        comment = u"Created by MiniPyWin32Cred test suite"
+        # given
+        target = u'jone@doe'
+        r_credentials = self._demo_credentials()
+        CredWrite(r_credentials)
 
-        target = "{0}@{1}".format(username, password)
-
-        credentials = {"Type": CRED_TYPE_GENERIC,
-                       "TargetName": target,
-                       "UserName": username,
-                       "CredentialBlob": password,
-                       "Comment": comment,
-                       "Persist": CRED_PERSIST_ENTERPRISE}
-
-        CredWrite(credentials)
-
-        res = win32cred.CredRead(
+        # when
+        credentials = win32cred.CredRead(
             TargetName=target, Type=CRED_TYPE_GENERIC)
 
-        self.assertEqual(res["Type"], CRED_TYPE_GENERIC)
-        self.assertEqual(res["UserName"], username)
-        self.assertEqual(res["TargetName"], target)
-        self.assertEqual(res["Comment"], comment)
+        # then
+        self.assertEqual(credentials["Type"], CRED_TYPE_GENERIC)
+        self.assertEqual(credentials["UserName"], u"jone")
+        self.assertEqual(credentials["TargetName"], u'jone@doe')
         self.assertEqual(
-            res["CredentialBlob"].decode('utf-16'), password)
+            credentials["Comment"], u"Created by MiniPyWin32Cred test suite")
+        self.assertEqual(
+            credentials["CredentialBlob"].decode('utf-16'), u"doefsajfsakfj")
 
     def test_read_from_pywin32(self):
-        username = "john"
-        password = "doe"
-        comment = u"Created by MiniPyWin32Cred test suite"
-
-        target = u"{0}@{1}".format(username, password)
-
-        r_credentials = {
-            u"Type": CRED_TYPE_GENERIC,
-            u"TargetName": target,
-            u"UserName": username,
-            u"CredentialBlob": password,
-            u"Comment": comment,
-            u"Persist": CRED_PERSIST_ENTERPRISE}
+        # given
+        target = u'jone@doe'
+        r_credentials = self._demo_credentials()
         win32cred.CredWrite(r_credentials)
 
+        # when
         credentials = CredRead(target, CRED_TYPE_GENERIC)
 
+        # then
         # XXX: the fact that we have to decode the password when reading, but
         # not encode when writing is a bit strange, but that's what pywin32
         # seems to do as well, and we try to be backward compatible here.
-        self.assertEqual(credentials["UserName"], username)
-        self.assertEqual(credentials["TargetName"], target)
-        self.assertEqual(credentials["Comment"], comment)
+        self.assertEqual(credentials["UserName"], u"jone")
+        self.assertEqual(credentials["TargetName"], u'jone@doe')
         self.assertEqual(
-            credentials["CredentialBlob"].decode("utf-16"), password)
+            credentials["Comment"], u"Created by MiniPyWin32Cred test suite")
+        self.assertEqual(
+            credentials["CredentialBlob"].decode('utf-16'), u"doefsajfsakfj")
 
     def test_read_write(self):
-        username = "john"
-        password = "doe"
-        comment = u"Created by MiniPyWin32Cred test suite"
+        # given
+        target = u'jone@doe'
+        r_credentials = self._demo_credentials()
 
-        target = u"{0}@{1}".format(username, password)
-
-        r_credentials = {
-            u"Type": CRED_TYPE_GENERIC,
-            u"TargetName": target,
-            u"UserName": username,
-            u"CredentialBlob": password,
-            u"Comment": comment,
-            u"Persist": CRED_PERSIST_ENTERPRISE}
+        # when
         CredWrite(r_credentials)
-
         credentials = CredRead(target, CRED_TYPE_GENERIC)
 
+        # then
         # XXX: the fact that we have to decode the password when reading, but
         # not encode when writing is a bit strange, but that's what pywin32
         # seems to do as well, and we try to be backward compatible here.
-        self.assertEqual(credentials["UserName"], username)
-        self.assertEqual(credentials["TargetName"], target)
-        self.assertEqual(credentials["Comment"], comment)
+        self.assertEqual(credentials["UserName"], u"jone")
+        self.assertEqual(credentials["TargetName"], u'jone@doe')
         self.assertEqual(
-            credentials["CredentialBlob"].decode("utf-16"), password)
+            credentials["Comment"], u"Created by MiniPyWin32Cred test suite")
+        self.assertEqual(
+            credentials["CredentialBlob"].decode('utf-16'), u"doefsajfsakfj")
 
     def test_enumerate_filter(self):
-        username = "john"
-        password = "doe"
-        comment = u"Created by MiniPyWin32Cred test suite"
-        target = u"{0}@{1}".format(username, password)
-        r_credentials = {
-            u"Type": CRED_TYPE_GENERIC,
-            u"TargetName": target,
-            u"UserName": username,
-            u"CredentialBlob": password,
-            u"Comment": comment,
-            u"Persist": CRED_PERSIST_ENTERPRISE}
+        # given
+        r_credentials = self._demo_credentials()
         CredWrite(r_credentials)
 
-        credentials = CredEnumerate('john@doe')[0]
+        # when
+        credentials = CredEnumerate('jone*')[0]
+
+        # then
         # XXX: the fact that we have to decode the password when reading, but
         # not encode when writing is a bit strange, but that's what pywin32
         # seems to do as well, and we try to be backward compatible here.
-        self.assertEqual(credentials["UserName"], username)
-        self.assertEqual(credentials["TargetName"], target)
-        self.assertEqual(credentials["Comment"], comment)
+        self.assertEqual(credentials["UserName"], u"jone")
+        self.assertEqual(credentials["TargetName"], u'jone@doe')
         self.assertEqual(
-            credentials["CredentialBlob"].decode("utf-16"), password)
+            credentials["Comment"], u"Created by MiniPyWin32Cred test suite")
+        self.assertEqual(
+            credentials["CredentialBlob"].decode('utf-16'), u"doefsajfsakfj")
 
     def test_enumerate_no_filter(self):
-        username = "john"
-        password = "doe"
-        comment = u"Created by MiniPyWin32Cred test suite"
-        target = u"{0}@{1}".format(username, password)
-        r_credentials = {
-            u"Type": CRED_TYPE_GENERIC,
-            u"TargetName": target,
-            u"UserName": username,
-            u"CredentialBlob": password,
-            u"Comment": comment,
-            u"Persist": CRED_PERSIST_ENTERPRISE}
+        # given
+        r_credentials = self._demo_credentials()
         CredWrite(r_credentials)
 
+        # when
         credentials = CredEnumerate()
+
+        # then
         self.assertGreater(len(credentials), 1)
 
     def test_read_doesnt_exists(self):
+        # given
         target = "Floupi_dont_exists@MiniPyWin"
+
+        # when/then
         with self.assertRaises(error) as ctx:
             CredRead(target, CRED_TYPE_GENERIC)
         self.assertTrue(ctx.exception.winerror, ERROR_NOT_FOUND)
 
     def test_delete_simple(self):
-        username = "john"
-        password = "doe"
-        comment = "Created by MiniPyWin32Cred test suite"
-
-        target = "{0}@{1}".format(username, password)
-
-        r_credentials = {
-            "Type": CRED_TYPE_GENERIC,
-            "TargetName": target,
-            "UserName": username,
-            "CredentialBlob": password,
-            "Comment": comment,
-            "Persist": CRED_PERSIST_ENTERPRISE}
+        # given
+        target = u'jone@doe'
+        r_credentials = self._demo_credentials()
         CredWrite(r_credentials, 0)
-
         credentials = CredRead(target, CRED_TYPE_GENERIC)
         self.assertTrue(credentials is not None)
 
+        # when
         CredDelete(target, CRED_TYPE_GENERIC)
 
+        # then
         with self.assertRaises(error) as ctx:
             CredRead(target, CRED_TYPE_GENERIC)
         self.assertEqual(ctx.exception.winerror, ERROR_NOT_FOUND)
         self.assertEqual(ctx.exception.funcname, "CredRead")
 
     def test_delete_doesnt_exists(self):
+        # given
         target = u"Floupi_doesnt_exists@MiniPyWin32"
 
+        # when/then
         with self.assertRaises(error) as ctx:
             CredDelete(target, CRED_TYPE_GENERIC)
         self.assertEqual(ctx.exception.winerror, ERROR_NOT_FOUND)

--- a/win32ctypes/tests/test_win32cred.py
+++ b/win32ctypes/tests/test_win32cred.py
@@ -15,7 +15,8 @@ from win32ctypes.core._winerrors import ERROR_NOT_FOUND
 from win32ctypes.pywin32.pywintypes import error
 from win32ctypes.pywin32.win32cred import (
     CredDelete, CredRead, CredWrite, CredEnumerate,
-    CRED_PERSIST_ENTERPRISE, CRED_TYPE_GENERIC)
+    CRED_PERSIST_ENTERPRISE, CRED_TYPE_GENERIC,
+    CRED_ENUMERATE_ALL_CREDENTIALS)
 
 # find the pywin32 version
 version_file = os.path.join(
@@ -134,6 +135,17 @@ class TestCred(unittest.TestCase):
 
         # when
         credentials = CredEnumerate()
+
+        # then
+        self.assertGreater(len(credentials), 1)
+
+    def test_enumerate_all(self):
+        # given
+        r_credentials = self._demo_credentials()
+        CredWrite(r_credentials)
+
+        # when
+        credentials = CredEnumerate(Flags=CRED_ENUMERATE_ALL_CREDENTIALS)
 
         # then
         self.assertGreater(len(credentials), 1)

--- a/win32ctypes/tests/test_win32cred.py
+++ b/win32ctypes/tests/test_win32cred.py
@@ -32,7 +32,7 @@ class TestCred(unittest.TestCase):
 
     def setUp(self):
         try:
-            win32cred.CredDelete(u'jone@doe')
+            win32cred.CredDelete(u'jone@doe', 0)
         except error:
             pass
 


### PR DESCRIPTION
- Add code for CredEnumerate in the cffi backend (based on https://github.com/enthought/pywin32-ctypes/pull/109)
- Add code for CredEnumerate in ctypes
- Cleanup code a little bit
- Add tests for CredEnumerate

fixes #110