### PR TITLE
enable warnings as errors when testing and migrate away from deprecated import methods

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,12 +9,10 @@ on:
 jobs:
   tests:
     strategy:
-      fail-fast: false
       matrix:
         python-version: [3.6, 3.7, 3.8, 3.9, "3.10", "3.11", "3.12"]
         os: [windows-2019]
     runs-on: ${{ matrix.os }}
-    needs: code-lint
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   tests:
     strategy:
+      fail-fast: false
       matrix:
         python-version: [3.6, 3.7, 3.8, 3.9, "3.10", "3.11", "3.12"]
         os: [windows-2019]

--- a/pywin32-tests/test_pywintypes.py
+++ b/pywin32-tests/test_pywintypes.py
@@ -11,6 +11,9 @@ import shutil
 import faulthandler
 import datetime
 import time
+import warnings
+
+warnings.simplefilter("error")
 
 from win32ctypes import pywin32
 from win32ctypes.pywin32.pywintypes import error

--- a/win32ctypes/core/__init__.py
+++ b/win32ctypes/core/__init__.py
@@ -28,6 +28,7 @@ class BackendLoader(Loader):
 
     def create_module(self, spec):
         # TODO: this seems wrong, but let's see the behavior
+        #       please do tell me the right way :]
         return importlib.import_module(self.redirect_module)
  
     def exec_module(self, module):
@@ -48,9 +49,6 @@ class BackendFinder(MetaPathFinder):
                 redirected = f'win32ctypes.core.ctypes.{module_name}'
             else:
                 redirected = f'win32ctypes.core.cffi.{module_name}'
-            # spec = importlib.util.find_spec(redirected)
-            # spec.name = module_name
-            # return spec
             loader = BackendLoader(redirected)
             return importlib.machinery.ModuleSpec(module_name, loader)
         else:

--- a/win32ctypes/core/__init__.py
+++ b/win32ctypes/core/__init__.py
@@ -21,15 +21,24 @@ else:
     _backend = 'cffi'
 
 
-class BackendLoader(Loader):
+# class BackendLoader(Loader):
 
-    def __init__(self, redirect_module):
-        self.redirect_module = redirect_module
+#     def __init__(self, redirect_module):
+#         self.redirect_module = redirect_module
 
-    def load_module(self, fullname):
-        module = importlib.import_module(self.redirect_module)
-        sys.modules[fullname] = module
-        return module
+#     def create_module(self, spec):
+#         return importlib.import_module(self.redirect_module)
+        
+#         importlib.util.module_from_spec(spec)
+#         return None
+
+#     def exec_module(self, module):
+        
+
+#     def load_module(self, fullname):
+#         module = importlib.import_module(self.redirect_module)
+#         sys.modules[fullname] = module
+#         return module
 
 
 class BackendFinder(MetaPathFinder):
@@ -46,8 +55,11 @@ class BackendFinder(MetaPathFinder):
                 redirected = f'win32ctypes.core.ctypes.{module_name}'
             else:
                 redirected = f'win32ctypes.core.cffi.{module_name}'
-            loader = BackendLoader(redirected)
-            return importlib.machinery.ModuleSpec(module_name, loader)
+            spec = importlib.util.find_spec(redirected)
+            spec.name = module_name
+            return spec
+            # loader = BackendLoader(redirected)
+            # return importlib.machinery.ModuleSpec(module_name, loader)
         else:
             return None
 

--- a/win32ctypes/core/__init__.py
+++ b/win32ctypes/core/__init__.py
@@ -21,24 +21,17 @@ else:
     _backend = 'cffi'
 
 
-# class BackendLoader(Loader):
+class BackendLoader(Loader):
 
-#     def __init__(self, redirect_module):
-#         self.redirect_module = redirect_module
+    def __init__(self, redirect_module):
+        self.redirect_module = redirect_module
 
-#     def create_module(self, spec):
-#         return importlib.import_module(self.redirect_module)
-        
-#         importlib.util.module_from_spec(spec)
-#         return None
-
-#     def exec_module(self, module):
-        
-
-#     def load_module(self, fullname):
-#         module = importlib.import_module(self.redirect_module)
-#         sys.modules[fullname] = module
-#         return module
+    def create_module(self, spec):
+        # TODO: this seems wrong, but let's see the behavior
+        return importlib.import_module(self.redirect_module)
+ 
+    def exec_module(self, module):
+        pass
 
 
 class BackendFinder(MetaPathFinder):
@@ -55,11 +48,11 @@ class BackendFinder(MetaPathFinder):
                 redirected = f'win32ctypes.core.ctypes.{module_name}'
             else:
                 redirected = f'win32ctypes.core.cffi.{module_name}'
-            spec = importlib.util.find_spec(redirected)
-            spec.name = module_name
-            return spec
-            # loader = BackendLoader(redirected)
-            # return importlib.machinery.ModuleSpec(module_name, loader)
+            # spec = importlib.util.find_spec(redirected)
+            # spec.name = module_name
+            # return spec
+            loader = BackendLoader(redirected)
+            return importlib.machinery.ModuleSpec(module_name, loader)
         else:
             return None
 


### PR DESCRIPTION
It turns out that my import failure noted over in https://github.com/jaraco/keyring/pull/683 is triggered by the fact we (not keyring) run our tests (using keyring and thus pywin32-ctypes) with warnings reported as errors.  This results in pywin32-ctypes failing to be imported due to some import related warnings.

These are taken from a PR in my fork where CI is running (without approval).

https://github.com/altendky/pywin32-ctypes/actions/runs/9375227229/job/25812921472?pr=1#step:5:163
```
  File "D:\a\pywin32-ctypes\pywin32-ctypes\pywin32-tests\test_pywintypes.py", line 18, in <module>
    from win32ctypes import pywin32
  File "D:\a\pywin32-ctypes\pywin32-ctypes\win32ctypes\pywin32\__init__.py", line 9, in <module>
    from win32ctypes.pywin32 import win32api
  File "D:\a\pywin32-ctypes\pywin32-ctypes\win32ctypes\pywin32\win32api.py", line 9, in <module>
    from win32ctypes.core import (
  File "<frozen importlib._bootstrap>", line 1176, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1147, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 673, in _load_unlocked
ImportWarning: BackendLoader.exec_module() not found; falling back to load_module()
```

I'll keep this updated as I understand this better.

Looks like the fallback that is happening is to `BackendLoader.load_module()`.

https://github.com/enthought/pywin32-ctypes/blob/83be1e315304fdee486fafecfe3380bff51a5f72/win32ctypes/core/__init__.py#L29-L32

https://docs.python.org/3.12/library/importlib.html#importlib.abc.Loader.load_module
> Deprecated since version 3.4: The recommended API for loading a module is [exec_module()](https://docs.python.org/3/library/importlib.html#importlib.abc.Loader.exec_module) (and [create_module()](https://docs.python.org/3/library/importlib.html#importlib.abc.Loader.create_module)). Loaders should implement it instead of [load_module()](https://docs.python.org/3/library/importlib.html#importlib.abc.Loader.load_module). The import machinery takes care of all the other responsibilities of [load_module()](https://docs.python.org/3/library/importlib.html#importlib.abc.Loader.load_module) when [exec_module()](https://docs.python.org/3/library/importlib.html#importlib.abc.Loader.exec_module) is implemented.

There is a warning about datetime utc tz aware etc etc that haas addressed in https://github.com/scalative/haas/commit/59809b1d4361cd3c4ead0ceaad1bab799c65d2d4 but is not yet released.
https://github.com/altendky/pywin32-ctypes/actions/runs/9376291633/job/25815980893?pr=1#step:5:96
> DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).